### PR TITLE
fixed: crash in Hierarchify() with empty cells

### DIFF
--- a/src/grid.h
+++ b/src/grid.h
@@ -1035,7 +1035,7 @@ struct Grid
         Selection s(this, 1, 0, xs-1, ys);
         MultiCellDeleteSub(doc, s);
         
-        foreachcell(c) if(c->grid) c->grid->Hierarchify(doc);    
+        foreachcell(c) if(c->grid && c->grid->xs > 1) c->grid->Hierarchify(doc);    
     }
 
     void MergeRow(Grid *tm)


### PR DESCRIPTION
Grids with width=1 are hierarchified trivially anyway. Empty cells in a table end up as empty cells in the hierarchy.
