### PR TITLE
Create files for BSD and GNU make with changes inside of Makefile.common

### DIFF
--- a/src/BSDmakefile
+++ b/src/BSDmakefile
@@ -1,0 +1,7 @@
+.if make(debug)
+CXXFLAGS+=	-g
+.elif make(release)
+CXXFLAGS+=	-O3
+.endif
+
+.include "Makefile.common"

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -1,0 +1,7 @@
+ifeq ($(findstring debug, $(MAKECMDGOALS)), debug)
+CXXFLAGS+=	-g
+else ifeq ($(findstring release, $(MAKECMDGOALS)), release)
+CXXFLAGS+=	-O3
+endif
+
+include Makefile.common

--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -1,5 +1,4 @@
-# Created by: lightside <lightside@gmx.com>
-# This file released into the public domain
+# Common Makefile for BSD and GNU make
 
 WX_CONFIG?=	wx-config
 WX_CXXFLAGS=	`$(WX_CONFIG) --cxxflags`
@@ -12,22 +11,25 @@ APPNAME=	treesheets
 SRCS=	main.cpp
 OBJS=	$(SRCS:.cpp=.o)
 
-all: CXXFLAGS+= -O3
-all: $(SRCS) $(APPNAME)
+debug: all
 
-debug: CXXFLAGS+= -g
-debug: $(SRCS) $(APPNAME)
+release: all
+
+all: $(SRCS) $(APPNAME)
 
 $(APPNAME): $(OBJS)
 	$(CXX) $(OBJS) $(LDFLAGS) -o $@
-	mv treesheets ../TS
-	rm -f *.o
 
 .o:
 	$(CXX) $(CXXFLAGS) $< -o $@
+
+install: all
+	cp -f $(APPNAME) ../TS
+
+deinstall:
+	rm -f ../TS/$(APPNAME)
 
 clean:
 	rm -f $(APPNAME) *.o
 
 .PHONY: all
-


### PR DESCRIPTION
Hello, Wouter van Oortmerssen.

Thanks for addition of Makefile, which I created a while ago on FreeBSD Bugzilla.

My initial version was compatible with BSD and GNU make variants. But you introduced some changes, which used as a GNU extensions and not compatible with BSD make.

I propose to create BSDmakefile and GNUmakefile with changes inside of Makefile.common.
The BSDmakefile (GNUmakefile) is alternative Makefile's name for BSD (GNU) make. This way, they might be used on BSD and Linux operating systems without additional dependencies on particular make system.

Also, I propose to move installation from "$(APPNAME)" target (goal) to "install" and create "deinstall" target for deinstallation. The C++ "-O3" compiler option (for CXXFLAGS) might be used on "release" target. This is useful in case of system-wide configuration (e.g. inside of /etc/make.conf) or custom options and adds more granularity.

The examples of basic usage:
Build executable with system-wide configuraion:
% make
Build executable with custom options from environment:
% env CXX=clang++ CXXFLAGS=-O2 WX_CONFIG=wxgtk2u-3.0-config make
Build and install executable file:
% make install
Deinstall executable file:
% make deinstall
Remove intermediate files:
% make clean
Build release version (with C++ "-O3" compiler option):
% make release
Build debug version (with C++ "-g" compiler option):
% make debug
Also possible to combine targets:
Build release version and install executable file:
% make release install
Build debug version and install executable file:
% make debug install
Deinstall executable and remove intermediate files, if needed:
% make deinstall clean

Tested on FreeBSD 10 for make and gmake variants.

Edit: Added example for environment.