### PR TITLE
Fix "Select First Child" keyboard shortcut

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -851,7 +851,7 @@ struct Document
                     return Action(dc, A_BACKSPACE);
 
                 case WXK_RETURN:         
-                    return Action(dc, A_ENTERCELL);
+                    return Action(dc, shift ? A_ENTERGRID : A_ENTERCELL);
 
                 case WXK_ESCAPE:            // docs say it can be used as a menu accelerator, but it does not trigger from there?
                     return Action(dc, A_CANCELEDIT);


### PR DESCRIPTION
The keyboard shortcut for Edit→Selection→Select First Child (Shift+Return) wasn't working (it doesn't look like it was implemented?). This tiny change fixes it.