### PR TITLE
Minor: Escape ampersand in Edit menu

### DIFF
--- a/src/myframe.h
+++ b/src/myframe.h
@@ -312,7 +312,7 @@ struct MyFrame : wxFrame
         editmenu->AppendSeparator();
         editmenu->AppendSubMenu(selmenu,  L"&Selection...");
         editmenu->AppendSubMenu(orgmenu,  L"&Grid Reorganization...");
-        editmenu->AppendSubMenu(laymenu,  L"&Layout & Render Style...");
+        editmenu->AppendSubMenu(laymenu,  L"&Layout && Render Style...");
         editmenu->AppendSubMenu(imgmenu,  L"&Images...");
         editmenu->AppendSubMenu(navmenu,  L"&Browsing...");
         editmenu->AppendSubMenu(temenu,   L"Text &Editing...");


### PR DESCRIPTION
The ampersand in "Layout & Render Style" wasn't properly escaped, so wxWidgets interpreted "& " as a mnemonic and rendered it as "Layout _Render Style".