### PR TITLE
Implemented the correct handling of non-latin symbols particulary in isalphanum checks

### DIFF
--- a/src/myapp.h
+++ b/src/myapp.h
@@ -27,6 +27,9 @@ struct MyApp : wxApp
         wxDisableAsserts();
         #endif
 
+        // set locale for the correct handling of non-latin symbols
+        std::setlocale(LC_ALL,"");
+
         bool portable = false;
         wxString filename;
         for (int i = 1; i < argc; i++)

--- a/src/myapp.h
+++ b/src/myapp.h
@@ -28,7 +28,7 @@ struct MyApp : wxApp
         #endif
 
         // set locale for the correct handling of non-latin symbols
-        std::setlocale(LC_ALL,"");
+        std::setlocale(LC_CTYPE,"");
 
         bool portable = false;
         wxString filename;

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -57,6 +57,8 @@
 
 #include <wx/display.h>
 
+#include <clocale>
+
 //#include <wx/uiaction.h>
 
 //#include <wx/overlay.h>


### PR DESCRIPTION
The wxIsalnum function (being just a wrapper of the standard iswalnum function) and some others are locale-dependent, thus they are working incorrectly when checking non-ASCII characters, since by default LC_ALL is set to C. I added the call of the setlocale function which set the locale to the system environment locale. This fixed navigation by words, opening files with names containing non-ASCII symbols and probably something else.