### PR TITLE
Removed dependence on c11 features (auto type)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ WX_CXXFLAGS=	`$(WX_CONFIG) --cxxflags`
 WX_LIBS=	`$(WX_CONFIG) --libs aui adv core xml net`
 PACKAGE_VERSION?=	__DATE__
 CXX?=	c++
-CXXFLAGS+=	-DPACKAGE_VERSION=$(PACKAGE_VERSION) $(WX_CXXFLAGS)
+CXXFLAGS+=	-DPACKAGE_VERSION=$(PACKAGE_VERSION) -std=c++11 $(WX_CXXFLAGS)
 LDFLAGS+=	$(WX_LIBS)
 
 ARCH=	$(firstword $(shell uname -m))

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ WX_CXXFLAGS=	`$(WX_CONFIG) --cxxflags`
 WX_LIBS=	`$(WX_CONFIG) --libs aui adv core xml net`
 PACKAGE_VERSION?=	__DATE__
 CXX?=	c++
-CXXFLAGS+=	-DPACKAGE_VERSION=$(PACKAGE_VERSION) -std=c++11 $(WX_CXXFLAGS)
+CXXFLAGS+=	-DPACKAGE_VERSION=$(PACKAGE_VERSION) $(WX_CXXFLAGS)
 LDFLAGS+=	$(WX_LIBS)
 
 ARCH=	$(firstword $(shell uname -m))

--- a/src/document.h
+++ b/src/document.h
@@ -1225,7 +1225,7 @@ struct Document
             case A_CUSTKEY:
             {
                 wxArrayString strs;
-                MyFrame::MenuString & ms = sys->frame->menustrings;
+                MyFrame::MenuString &ms = sys->frame->menustrings;
                 for (MyFrame::MenuStringIterator it = ms.begin(); it != ms.end(); ++it) strs.push_back(it->first);
                 wxSingleChoiceDialog choice(sys->frame, L"Please pick a menu item to change the key binding for",
                                             L"Key binding", strs);

--- a/src/document.h
+++ b/src/document.h
@@ -1225,18 +1225,18 @@ struct Document
             case A_CUSTKEY:
             {
                 wxArrayString strs;
-                auto &ms = sys->frame->menustrings;
-                for (auto it = ms.begin(); it != ms.end(); ++it) strs.push_back(it->first);
+                MyFrame::MenuString & ms = sys->frame->menustrings;
+                for (MyFrame::MenuStringIterator it = ms.begin(); it != ms.end(); ++it) strs.push_back(it->first);
                 wxSingleChoiceDialog choice(sys->frame, L"Please pick a menu item to change the key binding for",
                                             L"Key binding", strs);
                 if (choice.ShowModal() == wxID_OK)
                 {
-                    auto sel = choice.GetSelection();
+                    int sel = choice.GetSelection();
                     wxTextEntryDialog textentry(sys->frame, "Please enter the new key binding string", "Key binding",
                                                 ms[sel].second);
                     if (textentry.ShowModal() == wxID_OK)
                     {
-                        auto key = textentry.GetValue();
+                        wxString key = textentry.GetValue();
                         ms[sel].second = key;
 
                         sys->cfg->Write(ms[sel].first, key);

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -1,5 +1,7 @@
 struct MyFrame : wxFrame
 {
+    typedef std::vector<std::pair<wxString, wxString> > MenuString;
+    typedef std::vector<std::pair<wxString, wxString> >::iterator MenuStringIterator;
     wxMenu *editmenupopup;
     wxString exepath_;
     wxFileHistory filehistory;
@@ -33,13 +35,13 @@ struct MyFrame : wxFrame
         return exepath_ + "/" + relpath;
     }
 
-    std::vector<std::pair<wxString, wxString>> menustrings;
+    MenuString menustrings;
 
     void MyAppend(wxMenu *menu, int tag, const wxString &contents, const wchar_t *help = L"")
     {
         wxString item = contents;
         wxString key = L"";
-        auto pos = contents.Find("\t");
+        int pos = contents.Find("\t");
         if (pos >= 0)
         {
             item = contents.Mid(0, pos);
@@ -48,7 +50,7 @@ struct MyFrame : wxFrame
 
         key = sys->cfg->Read(item, key);
 
-        auto newcontents = item;
+        wxString newcontents = item;
         if (key.Length()) newcontents += "\t" + key;
 
         menu->Append(tag, newcontents, help);
@@ -647,7 +649,7 @@ struct MyFrame : wxFrame
         const int screenx = wxSystemSettings::GetMetric(wxSYS_SCREEN_X);
         const int screeny = wxSystemSettings::GetMetric(wxSYS_SCREEN_Y);
         */
-        auto disprect = wxDisplay(wxDisplay::GetFromWindow(this)).GetClientArea();
+        wxRect disprect = wxDisplay(wxDisplay::GetFromWindow(this)).GetClientArea();
         const int screenx = disprect.width - disprect.x;
         const int screeny = disprect.height - disprect.y;
 

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -1,7 +1,7 @@
 struct MyFrame : wxFrame
 {
     typedef std::vector<std::pair<wxString, wxString> > MenuString;
-    typedef std::vector<std::pair<wxString, wxString> >::iterator MenuStringIterator;
+    typedef MenuString::iterator MenuStringIterator;
     wxMenu *editmenupopup;
     wxString exepath_;
     wxFileHistory filehistory;

--- a/src/system.h
+++ b/src/system.h
@@ -241,7 +241,7 @@ struct System
                         wxDataInputStream dis(fis);
                         if (versionlastloaded < 9) dis.ReadString();
                         wxImage im;
-                        auto beforepng = fis.TellI();
+                        off_t beforepng = fis.TellI();
                         bool ok = im.LoadFile(fis);
                         // ok = false;
                         if (!ok)
@@ -258,7 +258,7 @@ struct System
                             dis.BigEndianOrdered(true);
                             for (;;)  // Skip all chunks.
                             {
-                                auto len = dis.Read32();
+                                wxInt32 len = dis.Read32();
                                 char fourcc[4];
                                 fis.Read(fourcc, 4);
                                 fis.SeekI(len, wxFromCurrent);  // skip data


### PR DESCRIPTION
Not sure what your motivation for using c11 features is.
I believe less is more; the changes in this branch allow the code to be built without c11 features.
I have built this on Ubuntu, but I haven't tested on other flavours of Linux or on Windows or Mac, so if your motivation for c11 has to do with cross-platform compatibility, you can reject this pull request.
