### PR TITLE
Remove unused rule

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -32,9 +32,6 @@ all: $(SRCS) $(APPNAME)
 $(APPNAME): $(OBJS)
 	$(CXX) $(OBJS) $(LDFLAGS) -o $@
 
-.o:
-	$(CXX) $(CXXFLAGS) $< -o $@
-
 install: all
 	cp -f $(APPNAME) ../TS
 


### PR DESCRIPTION
The rule `.o` matches nothing, and treesheets was relying on make's implicit pre-defined `*.o` rule anyway. So just delete it to avoid confusing people.