### PR TITLE
 CI Passes on linux and os/x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,81 @@
+# Add [ci skip] to the commit message to prevent test execution
+# whitelist
+branches:
+  only:
+    - master 
+    - testing
+
+notifications:
+  slack:
+    on_success: change
+
+cache:
+  directories:
+    - wxWidgets
+    - wxWidgets/buid_osx
+
+
 language: cpp
-sudo: required
+os:
+  - linux
+  - osx
+
 dist: trusty
+sudo: required
+
 compiler: gcc
-os: linux
-install: sudo apt-get install -y libwxgtk3.0-dev
-script: cd src && make
+
+env: 
+  - RMRF_WXWIDGETS="" WXLIB="libwxgtk3.1-dev"
+
+# Here is the build matrix (runtime and enviroment)
+matrix:
+  allow_failures:
+    - os: linux
+      env: RMRF_WXWIDGETS="" WXLIB="libwxgtk3.1-dev"
+  include: 
+    - os: linux
+      env: RMRF_WXWIDGETS="" WXLIB="libwxgtk3.0-dev"
+    - os: osx
+      osx_image: xcode7.2
+      compiler: gcc clang
+      env: RMRF_WXWIDGETS="Y" WXLIB="libwxgtk3.1-dev"
+  exclude: 
+    - os: osx
+      compiler: gcc
+      env: RMRF_WXWIDGETS="" WXLIB="libwxgtk3.1-dev"
+
+# Here is the setup script
+install:
+  - if  [[ -n "$RMRF_WXWIDGETS" ]]; then rm -rf wxWidgets ; fi
+  - if  [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      if  [[ ! -d wxWidgets ]]; then
+         git submodule init && 
+         git submodule add --depth 1 -f https://github.com/wxWidgets/wxWidgets.git; 
+      fi; 
+      git submodule update --depth 1 --recursive;
+      if  [[ ! -d wxWidgets/build_osx ]]; then
+         mkdir -p wxWidgets/build_osx ;
+      fi;
+      pushd wxWidgets/build_osx &&
+      ../configure --enable-unicode --enable-optimize=-O2 --disable-shared --with-osx_cocoa CFLAGS="-arch i386" CXXFLAGS="-arch i386 -stdlib=libc++" CPPFLAGS="-arch i386" LDFLAGS="-arch i386 -stdlib=libc++" OBJCFLAGS="-arch i386" OBJCXXFLAGS="-arch i386 -stdlib=libc++" --with-macosx-sdk=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk --with-macosx-version-min=10.7 CC=clang CXX=clang++ &&
+      make -j 4 &&
+      sudo make install &&
+      popd ;
+    else
+      if  [[ "$WXLIB" = "libwxgtk3.1-dev" ]]; then 
+        sudo apt-key adv --fetch-keys http://repos.codelite.org/CodeLite.asc &&
+        sudo apt-add-repository 'deb http://repos.codelite.org/wx3.1.0/ubuntu/ trusty universe';
+      fi;
+      sudo apt-get update && 
+      sudo apt-get install -y $WXLIB ; 
+    fi
+
+# Here is the test script
+script:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      xcodebuild -project osx/TreeSheets/TreeSheets.xcodeproj ;
+    else
+      cd src && 
+      make -j 4; 
+    fi


### PR DESCRIPTION
CI Passes on linux and os/x 

Experimental support for wxWidgets 3.1 in linux
To flush cache, edit .travis.yml to set  RMRF_WXWIDGETS to a non-empty string 
(this is the default for osx: for faster CI testing, reset osx to RMRF_WXWIDGETS="")
CI integration occurs only on master and testing branch