### PR TITLE
Linux: fixed typing characters using AltGr

### DIFF
--- a/src/mycanvas.h
+++ b/src/mycanvas.h
@@ -113,7 +113,7 @@ struct TSCanvas : public wxScrolledWindow {
         // (scrolling) don't work.
         // The 128 makes sure unicode entry on e.g. Polish keyboards still works.
         // (on Linux in particular).
-        if (ce.AltDown() && ce.GetUnicodeKey() < 128) {
+        if ((ce.GetModifiers() == wxMOD_ALT) && (ce.GetUnicodeKey() < 128)) {
             ce.Skip();
             return;
         }


### PR DESCRIPTION
Thanks very much for this outstanding software !

On Linux, it was impossible to enter characters using the AltGr key, because of the way the Alt modifier is detected in TSCanvas::OnChar().

You can find an explanation in the source code of [wx/kbdstate.h](https://github.com/wxWidgets/wxWidgets/blob/master/interface/wx/kbdstate.h
):

> when using [AltDown()], you also have to remember to test that none of the other modifiers is pressed (...) and forgetting to do it can result in serious program bugs (e.g. program not working with European keyboard layout where AltGr key which is seen by the program as combination of CTRL and ALT is used).

This pull request fixes that.

Cheers !