### PR TITLE
Make 'Shift + Enter' create a new grid in a cell

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -1486,7 +1486,7 @@ struct Document {
             }
 
             case A_ENTERGRID:
-                if (!c->grid) return NoGrid();
+                if (!c->grid) Action(dc, A_NEWGRID);
                 selected = Selection(c->grid, 0, 0, 1, 1);
                 ScrollOrZoom(dc, true);
                 return nullptr;


### PR DESCRIPTION
If there isn't a grid in a cell, shift enter should make one (as mentioned in [this issue](https://github.com/aardappel/treesheets/issues/95)

The change itself is very simple - instead of the code calling NoGrid() if there's no grid, it re-calls Action as if Insert had been pressed.

I'd like to also modify the tutorial (cell 10) to say "INSERT or SHIFT + ENTER", but I don't know where I would submit that change.