### PR TITLE
Add options to delete the word before and after the cursor

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -1126,6 +1126,16 @@ struct Document {
                 ZoomOutIfNoGrid(dc);
                 return nullptr;
 
+            case A_DELETE_WORD:
+                if (c && selected.TextEdit()) {
+                    if (selected.cursor == c->text.t.Len()) return nullptr;
+                    c->AddUndo(this);
+                    c->text.DeleteWord(selected);
+                    Refresh();
+                } 
+                ZoomOutIfNoGrid(dc);
+                return nullptr;
+
             case A_COPYCT:
             case A_CUT:
             case A_COPY:
@@ -1555,6 +1565,14 @@ struct Document {
                 else
                     Refresh();
                 selected.ExitEdit(this);
+                return nullptr;
+
+            case A_BACKSPACE_WORD:
+                if (selected.cursorend == 0) return nullptr;
+                c->AddUndo(this);
+                c->text.BackspaceWord(selected);
+                Refresh();
+                ZoomOutIfNoGrid(dc);
                 return nullptr;
 
             // FIXME: this functionality is really SCHOME, SHOME should be within line

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,6 +61,8 @@ enum {
     A_TRANSPOSE,
     A_DELETE,
     A_BACKSPACE,
+    A_DELETE_WORD,
+    A_BACKSPACE_WORD,
     A_LEFT,
     A_RIGHT,
     A_UP,

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -381,6 +381,10 @@ struct MyFrame : wxFrame {
             MyAppend(
                 editmenu, A_BACKSPACE, _(L"Delete Before\tBACK"),
                 _(L"Deletes the column of cells before the selected grid line, or the row above"));
+            MyAppend(editmenu, A_DELETE_WORD, _(L"Delete Word After\tCTRL+DEL"),
+                     _(L"Deletes the entire word after the cursor"));
+            MyAppend(editmenu, A_BACKSPACE_WORD, _(L"Delete Word Before\tCTRL+BACK"),
+                     _(L"Deletes the entire word before the cursor"));
             editmenu->AppendSeparator();
             MyAppend(editmenu, A_NEWGRID,
                      #ifdef __WXMAC__

--- a/src/text.h
+++ b/src/text.h
@@ -336,12 +336,22 @@ struct Text {
         }
     }
 
-    void SelectWord(Selection &s) {
-        if (s.cursor >= (int)t.Len()) return;
-        s.cursorend = s.cursor + 1;
+    void ExpandToWord(Selection &s) {
         if (!wxIsalnum(t[s.cursor])) return;
         while (s.cursor > 0 && wxIsalnum(t[s.cursor - 1])) s.cursor--;
         while (s.cursorend < (int)t.Len() && wxIsalnum(t[s.cursorend])) s.cursorend++;
+    }
+
+    void SelectWord(Selection &s) {
+        if (s.cursor >= (int)t.Len()) return;
+        s.cursorend = s.cursor + 1;
+        ExpandToWord(s);
+    }
+
+    void SelectWordBefore(Selection &s) {
+        if (s.cursor <= 1) return;
+        s.cursorend = s.cursor--;
+        ExpandToWord(s);
     }
 
     bool RangeSelRemove(Selection &s) {
@@ -386,6 +396,14 @@ struct Text {
                 t.Remove(--s.cursor, 1);
                 --s.cursorend;
             };
+    }
+    void DeleteWord(Selection &s) {
+        SelectWord(s);
+        Delete(s);
+    }
+    void BackspaceWord(Selection &s) {
+        SelectWordBefore(s);
+        Backspace(s);
     }
     void Key(int k, Selection &s) {
         RangeSelRemove(s);


### PR DESCRIPTION
The hotkeys ctrl+backspace and ctrl+delete can be used
#99
#106