### PR TITLE
Screen sharing improvements: zen mode, window size API

### DIFF
--- a/TS/scripts/Set Window Size.lobster
+++ b/TS/scripts/Set Window Size.lobster
@@ -1,0 +1,7 @@
+// Set the window size to a predefined value.
+// Use case: Program sharing over common messaging software
+
+//ts_set_window_size(1920, 1080)
+ts_set_window_size(1366, 768)
+//ts_set_window_size(1280, 720)
+//ts_set_window_size(1024, 768)

--- a/TS/scripts/Set Window Size.lobster
+++ b/TS/scripts/Set Window Size.lobster
@@ -1,7 +1,0 @@
-// Set the window size to a predefined value.
-// Use case: Program sharing over common messaging software
-
-//ts_set_window_size(1920, 1080)
-ts_set_window_size(1366, 768)
-//ts_set_window_size(1280, 720)
-//ts_set_window_size(1024, 768)

--- a/src/lobster_impl.cpp
+++ b/src/lobster_impl.cpp
@@ -157,6 +157,12 @@ nfr("ts_load_document", "filename", "S", "B",
         return Value(si->LoadDocument(filename.sval()->data()));
     });
 
+nfr("ts_set_window_size", "width,height", "II", "", "resizes the window",
+    [](VM &vm, Value &w, Value &h) {
+        si->SetWindowSize(w.intval(), h.intval());
+        return Value();
+    });
+
 }
 
 NativeRegistry natreg;  // FIXME: global.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,6 +141,7 @@ enum {
     A_TOTRAY,
     A_AUTOSAVE,
     A_FULLSCREEN,
+    A_ZEN_MODE,
     A_SCALED,
     A_SCOLS,
     A_SROWS,

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -21,6 +21,7 @@ struct MyFrame : wxFrame {
     bool watcherwaitingforuser;
     double csf, csf_orig;
     std::vector<std::string> scripts_in_menu;
+    bool zenmode;
 
     wxString GetPath(const wxString &relpath) {
         if (!exepath_.Length()) return relpath;
@@ -58,7 +59,8 @@ struct MyFrame : wxFrame {
           fromclosebox(true),
           app(_app),
           watcherwaitingforuser(false),
-          watcher(nullptr) {
+          watcher(nullptr),
+          zenmode(false) {
         sys->frame = this;
 
         exepath_ = wxFileName(exename).GetPath();
@@ -924,6 +926,23 @@ struct MyFrame : wxFrame {
             case A_FULLSCREEN:
                 ShowFullScreen(!IsFullScreen());
                 if (IsFullScreen()) sw->Status(_(L"Press F11 to exit fullscreen mode."));
+                break;
+            case A_ZEN_MODE:
+                if (!IsFullScreen()) {
+                    wxToolBar *wtb = this->GetToolBar();
+                    wxStatusBar *wsb = this->GetStatusBar();
+                    if (wtb != nullptr)
+                        wtb->Show(zenmode);
+                    if (wsb != nullptr)
+                        wsb->Show(zenmode);
+                    this->SendSizeEvent();
+                    this->Refresh();
+                    if (wtb != nullptr)
+                        wtb->Refresh();
+                    if (wsb != nullptr)
+                        wsb->Refresh();
+                    zenmode = !zenmode;
+                }
                 break;
             case A_SEARCHF:
                 if (filter) {

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -477,6 +477,7 @@ struct MyFrame : wxFrame {
                  #else
                  _(L"Toggle &Scaled Presentation View\tF12"));
                  #endif
+        MyAppend(viewmenu, A_ZEN_MODE, _(L"Toggle Zen Mode"));
         viewmenu->AppendSubMenu(scrollmenu, _(L"Scroll Sheet..."));
         viewmenu->AppendSubMenu(filtermenu, _(L"Filter..."));
 

--- a/src/script_interface.h
+++ b/src/script_interface.h
@@ -28,6 +28,7 @@ struct ScriptInterface {
     virtual void SetRelativeSize(int s) = 0;
     virtual void SetStyle(int s) = 0;
     virtual void SetStatusMessage(std::string_view msg) = 0;
+    virtual void SetWindowSize(int width, int height) = 0;
     virtual std::string GetFileNameFromUser(bool is_save) = 0;
     virtual std::string GetFileName() = 0;
 };

--- a/src/treesheets_impl.h
+++ b/src/treesheets_impl.h
@@ -112,6 +112,10 @@ struct TreeSheetsScriptImpl : public ScriptInterface {
         sys->frame->GetCurTab()->Status(ws);
     }
 
+    void SetWindowSize(int width, int height) {
+        sys->frame->SetSize(width, height);
+    }
+
     std::string GetFileNameFromUser(bool is_save) {
         int flags = wxFD_CHANGE_DIR;
         if (is_save) flags |= wxFD_OVERWRITE_PROMPT | wxFD_SAVE;


### PR DESCRIPTION
This pull request offers two new features:

- zen mode: hide toolbar and statusbar
- window size scripting API

Intended use case:
When sharing TreeSheets over messaging tools, it may be useful to have a predefined window size with reduced user interface. 

Thanks for checking this request!