### PR TITLE
Added celltype to XML import / export

### DIFF
--- a/src/cell.h
+++ b/src/cell.h
@@ -233,6 +233,11 @@ struct Cell {
                 str.Prepend(wxString() << textcolor);
                 str.Prepend(L" colorfg=\"");
             }
+            if (celltype != CT_DATA) {
+                str.Prepend(L"\"");
+                str.Prepend(wxString() << celltype);
+                str.Prepend(L" type=\"");
+            }
             str.Prepend(L"<cell");
             str.Append(L' ', indent);
             str.Append(L"</cell>\n");

--- a/src/system.h
+++ b/src/system.h
@@ -482,6 +482,7 @@ struct System {
             c->text.stylebits = wxAtoi(n->GetAttribute(L"stylebits", L"0"));
             c->cellcolor = wxAtoi(n->GetAttribute(L"colorbg", L"16777215"));
             c->textcolor = wxAtoi(n->GetAttribute(L"colorfg", L"0"));
+            c->celltype = wxAtoi(n->GetAttribute(L"type", L"0"));
         }
 
         Vector<wxXmlNode *> ns;


### PR DESCRIPTION
A small improvement: XML import/export now keeps track of cell types (data, operator, variable, view).
Thanks for reviewing!