### PR TITLE
Fix 3 argument operator `if`

### DIFF
--- a/src/grid.h
+++ b/src/grid.h
@@ -797,14 +797,14 @@ struct Grid {
                         if (vert) {
                             if (acc && y + 2 < ys) {
                                 y += 2;
-                                return ev.Execute(op, move(acc), C(x, y - 2), C(x, y - 1));
+                                return ev.Execute(op, move(acc), C(x, y - 1), C(x, y));
                             } else {
                                 return nullptr;
                             }
                         } else {
                             if (acc && x + 2 < xs) {
                                 x += 2;
-                                return ev.Execute(op, move(acc), C(x - 2, y), C(x - 1, y));
+                                return ev.Execute(op, move(acc), C(x - 1, y), C(x, y));
                             } else {
                                 return nullptr;
                             }


### PR DESCRIPTION
I couldn't figure out how the `if` operator works, so I looked at the code, where I found what I think is a bug. The problem is that the code used the operator cell and the cell next to it as arguments instead of the next 2 cells.

Before:
| data | op | data | data | view |
| - | - | - | - | - |
| 0 | if | a | b | a |
| 1 | if | a | b |   |

After:
| data | op | data | data | view |
| - | - | - | - | - |
| 0 | if | a | b | b |
| 1 | if | a | b | a |

The `// IF is sofar the only ternary` comment in the code makes me think it should work like this. I have tested this both horizontally and vertically.