### PR TITLE
Explicity check for window focus before refocusing

### DIFF
--- a/src/myframe.h
+++ b/src/myframe.h
@@ -1046,7 +1046,9 @@ struct MyFrame : wxFrame {
     }
 
     void ReFocus() {
-        if (GetCurTab()) GetCurTab()->SetFocus();
+        if (wxWindow::HasFocus()) {
+            if (GetCurTab()) GetCurTab()->SetFocus();
+        }
     }
 
     void OnCellColor(wxCommandEvent &ce) {


### PR DESCRIPTION
Under some certain circumstances in a Linux desktop environment running on a Xorg server, the Treesheets window using the WxWidgets GTK3 frontend catches all input events - even those which are not intended for Treesheets. This leads Treesheets to set the focus on its current tab and thus on its window each time an input event is detected - even if the window had no focus. Explicitly check whether the Treesheets window has current focus in the window managing system and only if it has focus, refocus on the Treesheets current tab and window.

This fixes [#262](https://github.com/aardappel/treesheets/issues/262).