### PR TITLE
Paint directly on Linux

### DIFF
--- a/src/mycanvas.h
+++ b/src/mycanvas.h
@@ -30,6 +30,8 @@ struct TSCanvas : public wxScrolledWindow {
     void OnPaint(wxPaintEvent &event) {
         #ifdef __WXMAC__
             wxPaintDC dc(this);
+        #elif __WXGTK__
+            wxPaintDC dc(this);
         #else
             auto sz = GetClientSize();
             if (sz.GetX() <= 0 || sz.GetY() <= 0) return;


### PR DESCRIPTION
Instead of using a bitmap for double-buffering, draw directly like on MacOS. This avoids the case that the bitmap has to be resized for HiDPI scaling. Instead, scaling is considered during the paint.

This fixes #253 for Linux (wxGTK).