### PR TITLE
More specific loading of the localized tutorial

### DIFF
--- a/src/system.h
+++ b/src/system.h
@@ -209,13 +209,16 @@ struct System {
     void LoadTut() {
         auto lang = frame->app->locale.GetCanonicalName();
 
-        if (lang.Len() == 5 && LoadDB(frame->GetDocPath(L"examples/tutorial-" + lang + ".cts"))[0]) {
-            lang.Truncate(2);
+        if (lang.Len() == 5 && !LoadDB(frame->GetDocPath(L"examples/tutorial-" + lang + ".cts"))[0]) {
+            return;
         }
 
-        if (lang.Len() == 2 && LoadDB(frame->GetDocPath(L"examples/tutorial-" + lang + ".cts"))[0]) {
-            LoadDB(frame->GetDocPath(L"examples/tutorial.cts"));
+        lang.Truncate(2);
+        if (lang.Len() == 2 && !LoadDB(frame->GetDocPath(L"examples/tutorial-" + lang + ".cts"))[0]) {
+            return;
         }
+
+        LoadDB(frame->GetDocPath(L"examples/tutorial.cts"));
     }
 
     void LoadOpRef() { LoadDB(frame->GetDocPath(L"examples/operation-reference.cts")); }

--- a/src/system.h
+++ b/src/system.h
@@ -208,8 +208,12 @@ struct System {
 
     void LoadTut() {
         auto lang = frame->app->locale.GetCanonicalName();
-        lang.Truncate(2);
-        if (LoadDB(frame->GetDocPath(L"examples/tutorial-" + lang + ".cts"))[0]) {
+
+        if (lang.Len() == 5 && LoadDB(frame->GetDocPath(L"examples/tutorial-" + lang + ".cts"))[0]) {
+            lang.Truncate(2);
+        }
+
+        if (lang.Len() == 2 && LoadDB(frame->GetDocPath(L"examples/tutorial-" + lang + ".cts"))[0]) {
             LoadDB(frame->GetDocPath(L"examples/tutorial.cts"));
         }
     }


### PR DESCRIPTION
First try and load the file ending with the five-letter canonical form of the current locale name, e.g. `tutorial-pt_BR.cts`. Failing that, try and load the file ending with the two-letter canonical form of the current locale name, e.g. `tutorial-pt.cts`. Failing that, just load `tutorial.cts`, and be done with it.