### PR TITLE
Treat original PNG as wxDF_PNG or wxDF_BITMAP

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -1554,7 +1554,11 @@ struct Document {
 
                 if (wxTheClipboard->Open()) {
                     if (!c->text.image->png_data.empty()) {
+                        #ifdef __WXMSW__
                         wxCustomDataObject *pngimage = new wxCustomDataObject(wxDF_PNG);
+                        #else
+                        wxCustomDataObject *pngimage = new wxCustomDataObject(wxDF_BITMAP);
+                        #endif
                         pngimage->SetData(c->text.image->png_data.size(), c->text.image->png_data.data());
                         wxTheClipboard->SetData(pngimage);
                     } else {


### PR DESCRIPTION
According to
<https://docs.wxwidgets.org/latest/classwx_data_format.html>, wxDF_PNG is only available for MSW, but not for Linux or Mac. Use wxDF_BITMAP for non-Windows platforms.