### PR TITLE
Some more convenience functionalities (Copy Image, allow wxDF_PNG also for pasting, Paste As Continuous Text)

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -1331,19 +1331,21 @@ struct Document {
                 }
                 return nullptr;
 
-            case A_PASTECT:
             case A_PASTE:
-                k == A_PASTECT ? pastect = true : pastect = false;
+            case A_PASTECT:
                 if (!(c = selected.ThinExpand(this))) return OneCell();
                 if (wxTheClipboard->Open()) {
                     wxTheClipboard->GetData(*dataobjc);
-                    PasteOrDrop();
+                    if (k == A_PASTECT) {
+                        PasteOrDrop(true);
+                    } else {
+                        PasteOrDrop();
+                    }
                     wxTheClipboard->Close();
                 } else if (sys->cellclipboard) {
                     c->Paste(this, sys->cellclipboard.get(), selected);
                     Refresh();
                 }
-                pastect = false;
                 return nullptr;
 
             case A_PASTESTYLE:
@@ -1742,11 +1744,9 @@ struct Document {
 
     void PasteSingleText(Cell *c, const wxString &t) { c->text.Insert(this, t, selected); }
 
-    bool pastect = false;
-
-    void PasteOrDrop() {
-        Cell *c = selected.ThinExpand(this);
-        if (!c) return;
+    void PasteOrDrop(bool pastect = false) {
+        Cell *c = selected.GetCell();
+        if (!(c = selected.ThinExpand(this))) return;
         wxBusyCursor wait;
         switch (dataobjc->GetReceivedFormat().GetType()) {
             case wxDF_FILENAME: {

--- a/src/document.h
+++ b/src/document.h
@@ -1757,6 +1757,9 @@ struct Document {
             case wxDF_BITMAP:
             case wxDF_DIB:
             case wxDF_TIFF:
+            #ifdef __WXMSW__
+            case wxDF_PNG:
+            #endif
                 if (dataobji->GetBitmap().GetRefData() != wxNullBitmap.GetRefData()) {
                     c->AddUndo(this);
                     SetImageBM(c, dataobji->GetBitmap().ConvertToImage(), sys->frame->csf);

--- a/src/document.h
+++ b/src/document.h
@@ -849,7 +849,7 @@ struct Document {
                 wxTheClipboard->SetData(new wxBitmapDataObject(cell->text.image->bm_orig));    
             }
             wxTheClipboard->Close();
-            }
+        }
         return _(L"Image copied to clipboard");
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -226,6 +226,7 @@ enum {
     A_DEFBGCOL,
     A_THINSELC,
     A_COPYCT,
+    A_PASTECT,
     A_MINISIZE,
     A_CUSTKEY,
     A_AUTOEXPORT,

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -397,6 +397,7 @@ struct MyFrame : wxFrame {
             MyAppend(editmenu, A_COPY, _(L"&Copy\tCTRL+c"));
             MyAppend(editmenu, A_COPYCT, _(L"Copy As Continuous Text"));
             MyAppend(editmenu, A_PASTE, _(L"&Paste\tCTRL+v"));
+            MyAppend(editmenu, A_PASTECT, _(L"Paste As Continuous Text\tCTRL+ALT+v"));
             MyAppend(editmenu, A_PASTESTYLE, _(L"Paste Style Only\tCTRL+SHIFT+v"),
                      _(L"only sets the colors and style of the copied cell, and keeps the text"));
             editmenu->AppendSeparator();


### PR DESCRIPTION
Dear Wouter

I thought that maybe we can add a little more convenience for the users with regards to the copy functionality.

If only one cell is selected and this cell has an image and no text is in the cell, then copy the image to clipboard.
If otherwise, copy text to clipboard.

Regards,
Tobias