### PR TITLE
Copy image if only image is in cell, small fixes

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -832,15 +832,9 @@ struct Document {
 
     const wxChar* CopyImageToClipboard(Cell *cell) {
         if (wxTheClipboard->Open()) {
-            #if defined(__WXMSW__) || defined(__WXGTK__)
+            #ifdef __WXGTK__
             if (!cell->text.image->png_data.empty()) {
-                wxCustomDataObject *pngimage = new wxCustomDataObject(
-                    #ifdef __WXMSW__
-                        wxDF_PNG
-                    #else
-                        wxDF_BITMAP
-                    #endif
-                );
+                wxCustomDataObject *pngimage = new wxCustomDataObject(wxDF_BITMAP);
                 pngimage->SetData(cell->text.image->png_data.size(), cell->text.image->png_data.data());
                 wxTheClipboard->SetData(pngimage);
             } else

--- a/src/document.h
+++ b/src/document.h
@@ -1757,6 +1757,9 @@ struct Document {
             case wxDF_BITMAP:
             case wxDF_DIB:
             case wxDF_TIFF:
+            #ifdef __WXMSW__
+            case wxDF_PNG:
+            #endif
                 if (dataobji->GetBitmap().GetRefData() != wxNullBitmap.GetRefData()) {
                     c->AddUndo(this);
                     SetImageBM(c, dataobji->GetBitmap().ConvertToImage(), sys->frame->csf);

--- a/src/document.h
+++ b/src/document.h
@@ -849,7 +849,7 @@ struct Document {
                 wxTheClipboard->SetData(new wxBitmapDataObject(cell->text.image->bm_orig));    
             }
             wxTheClipboard->Close();
-            }
+        }
         return _(L"Image copied to clipboard");
     }
 


### PR DESCRIPTION
Hello Wouter

This is an iterative approach. I stripped the "Paste As Continous Text" functionality away.
This pull requests only encompasses the possibility to copy the image directly if only the image is in the cell.
Also it added some small fix for also supporting wxDF_PNG for pasting from the clipboard and fixes the indentation issue.

Kind regards,
Tobias
