### PR TITLE
Reset layout when resetting image scale

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -1505,6 +1505,7 @@ struct Document {
                     if (c->text.image)
                         c->text.image->ResetScale(sys->frame->csf);
                 selected.g->cell->ResetChildren();
+                c->ResetLayout();
                 Refresh();
                 return nullptr;
             }


### PR DESCRIPTION
When the image scale is reset, also reset the layout to adapt the cell to the new dimensions of the image.