### PR TITLE
Fix memory leak when another instance is running

### DIFF
--- a/src/myapp.h
+++ b/src/myapp.h
@@ -109,6 +109,7 @@ struct MyApp : wxApp {
                 client.MakeConnection(
                     L"localhost", L"4242",
                     filename.Len() ? filename.wc_str() : L"*");  // fire and forget
+                DELETEP(instance_checker);
                 return false;
             }
         }


### PR DESCRIPTION
The instance_checker as a wxSingleInstanceChecker class instance shall be destroyed before exiting the program. This is in compliance with the class reference.

Memory leak found with the AddressSanitizer bundled with Clang.