### PR TITLE
Use pass-by-reference for cell looping and image resize functions

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -89,13 +89,13 @@ struct Document {
 
     #define loopcellsin(par, c) \
         CollectCells(par);      \
-        loopv(_i, itercells) for (Cell *c = itercells[_i]; c; c = nullptr)
+        loopv(_i, itercells) for (Cell *&c = itercells[_i]; c; c = nullptr)
     #define loopallcells(c)     \
         CollectCells(rootgrid); \
-        loopv(_i, itercells) for (Cell *c = itercells[_i]; c; c = nullptr)
+        loopv(_i, itercells) for (Cell *&c = itercells[_i]; c; c = nullptr)
     #define loopallcellssel(c, rec) \
         CollectCellsSel(rec);     \
-        loopv(_i, itercells) for (Cell *c = itercells[_i]; c; c = nullptr)
+        loopv(_i, itercells) for (Cell *&c = itercells[_i]; c; c = nullptr)
 
     Document()
         : sw(nullptr),

--- a/src/mywxtools.h
+++ b/src/mywxtools.h
@@ -149,7 +149,7 @@ struct ImageDropdown : wxOwnerDrawnComboBox {
     }
 };
 
-static void ScaleBitmap(const wxBitmap &src, double sc, wxBitmap &dest) {
+static void ScaleBitmap(const wxBitmap &src, const double &sc, wxBitmap &dest) {
     dest = wxBitmap(src.ConvertToImage().Scale(src.GetWidth() * sc, src.GetHeight() * sc,
                     wxIMAGE_QUALITY_HIGH));
 }

--- a/src/system.h
+++ b/src/system.h
@@ -19,18 +19,18 @@ struct Image {
     Image(wxBitmap _bm, uint64_t _hash, double _sc, vector<uint8_t> &&pd)
         : bm_orig(_bm), png_data(std::move(pd)), hash(_hash), display_scale(_sc) {}
 
-    void BitmapScale(double sc) {
+    void BitmapScale(const double &sc) {
         ScaleBitmap(bm_orig, sc, bm_orig);
         png_data.clear();
         bm_display = wxNullBitmap;
     }
 
-    void DisplayScale(double sc) {
+    void DisplayScale(const double &sc) {
         display_scale /= sc;
         bm_display = wxNullBitmap;
     }
 
-    void ResetScale(double sc) {
+    void ResetScale(const double &sc) {
         display_scale = sc;
         bm_display = wxNullBitmap;
     }


### PR DESCRIPTION
This avoids the copy of variables and pointers in the case of cell looping in general and in addition when calling the methods for images resize.