### PR TITLE
Add Save Image(s) to disk functionality

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -1552,7 +1552,8 @@ struct Document {
                 size_t counter = 0, counterpos;
                 wxString oimgfn, imgfn;
                 loopallcellssel(c, true) {
-                    if (c->text.image) {
+                    Image *tim = c->text.image;
+                    if (tim) {
                         if(!oimgfn) { // first encounter
                             oimgfn = ::wxFileSelector(
                                 _(L"Choose image file to save:"), L"", L"", L"png",
@@ -1572,8 +1573,14 @@ struct Document {
                                 imgfn.wx_str(), wxOK, sys->frame);
                             return _(L"Error writing to file.");
                             }
-                        wxImage im = c->text.image->bm_orig.ConvertToImage();
-                        im.SaveFile(imagefs, wxBITMAP_TYPE_PNG);
+                        if (tim->image_type == 'I' && !tim->image_data.empty()) {
+                            // We have a copy of the image data loaded.. this is WAY faster
+                            // than recompressing (~30x on image heavy files).
+                            imagefs.Write(tim->image_data.data(), tim->image_data.size());
+                        } else {
+                            wxImage im = tim->bm_orig.ConvertToImage();
+                            im.SaveFile(imagefs, wxBITMAP_TYPE_PNG);
+                        }
                         counter++;
                     }                
                 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -224,6 +224,7 @@ enum {
     A_IMAGESCF,
     A_IMAGESCN,
     A_IMAGECPY,
+    A_IMAGESVA,
     A_SAVE_AS_JPEG,
     A_SAVE_AS_PNG,
     A_HELPI,

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -368,14 +368,18 @@ struct MyFrame : wxFrame {
             wxMenu *imgmenu = new wxMenu();
             MyAppend(imgmenu, A_IMAGE, _(L"&Add Image"), _(L"Adds an image to the selected cell"));
             MyAppend(imgmenu, A_IMAGECPY, _(L"Copy Image to clipboard"), _(L"Copy the image in the selected cell to the clipboard"));
+            MyAppend(imgmenu, A_IMAGESVA, _(L"Save Image(s) to disk"), _(L"Save image(s) to disk. Multiple images will be saved with a counter appended to each file name."));
+            imgmenu->AppendSeparator();
             MyAppend(imgmenu, A_IMAGESCP, _(L"&Scale Image (re-sample pixels)"),
                      _(L"Change the image size if it is too big, by reducing the amount of pixels"));
             MyAppend(imgmenu, A_IMAGESCF, _(L"&Scale Image (display only)"),
                      _(L"Change the image size if it is too big or too small, by changing the size shown on screen. Applies to all uses of this image."));
             MyAppend(imgmenu, A_IMAGESCN, _(L"&Reset Scale (display only)"),
                      _(L"Change the scale to match DPI of the current display. Applies to all uses of this image."));
+            imgmenu->AppendSeparator();
             MyAppend(imgmenu, A_SAVE_AS_JPEG, _(L"Save image as JPEG"), _(L"Save the image in the TreeSheets file in JPEG format"));
             MyAppend(imgmenu, A_SAVE_AS_PNG, _(L"Save image as PNG (default)"), _(L"Save the image in the TreeSheets file in PNG format"));
+            imgmenu->AppendSeparator();
             MyAppend(imgmenu, A_IMAGER, _(L"&Remove Image(s)"),
                      _(L"Remove image(s) from the selected cells"));
 


### PR DESCRIPTION
Use-case:
* Saving images directly from TreeSheets to a location the user wants

If multiple images are in the selection, the file name of the images after the first one will be appended by a counter.