### PR TITLE
Read xs and ys value properly from the file

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -137,7 +137,7 @@ struct Document {
 
     uint Background() { return rootgrid ? rootgrid->cellcolor : 0xFFFFFF; }
 
-    void InitWith(Cell *r, wxString filename, Cell *ics, uint xs, uint ys) {
+    void InitWith(Cell *r, wxString filename, Cell *ics, int xs, int ys) {
         rootgrid = r;
         if(ics) {
             Grid* ipg = ics->parent->grid;

--- a/src/system.h
+++ b/src/system.h
@@ -268,6 +268,7 @@ struct System {
             wxBusyCursor wait;
             Cell *ics = nullptr;
             wxFFileInputStream fis(fn);
+            wxDataInputStream dis(fis);
             if (!fis.IsOk()) return _(L"Cannot open file.");
 
             char buf[4];
@@ -275,10 +276,10 @@ struct System {
             if (strncmp(buf, "TSFF", 4)) return _(L"Not a TreeSheets file.");
             fis.Read(&versionlastloaded, 1);
             if (versionlastloaded > TS_VERSION) return _(L"File of newer version.");
-            uint xs, ys;
+            int xs, ys;
             if (versionlastloaded >= 21) {
-                fis.Read(&xs, 1);
-                fis.Read(&ys, 1);
+                xs = dis.Read8();
+                ys = dis.Read8();
             } else {
                 xs = ys = 1;
             }
@@ -294,7 +295,6 @@ struct System {
                     case 'J': {
                         char iti = *buf;
                         wxBitmapType imt = imagetypes[*buf].first;
-                        wxDataInputStream dis(fis);
                         if (versionlastloaded < 9) dis.ReadString();
                         wxImage im;
                         double sc = versionlastloaded >= 19 ? dis.ReadDouble() : 1.0;


### PR DESCRIPTION
This fixes an incorrect reading of xs and ys values leading to a SEGFAULT because of garbage values supplied to DrawSelect otherwise.