### PR TITLE
Darken non-matching cells in search

### DIFF
--- a/src/cell.h
+++ b/src/cell.h
@@ -141,6 +141,12 @@ struct Cell {
                 p = p == doc->curdrawroot ? nullptr : p->parent;
             if (p) parentcolor = p->actualcellcolor;
         }
+
+        if(sys->darkennonmatchingcells && !text.IsInSearch()) {
+            uchar *cp = (uchar *)&actualcellcolor;
+            loop(i, 4) cp[i] = cp[i] * 800 / 1000;
+        }
+
         if (drawstyle == DS_GRID && actualcellcolor != parentcolor) {
             DrawRectangle(dc, actualcellcolor, bx - ml, by - mt, sx + ml + mr, sy + mt + mb);
         }

--- a/src/document.h
+++ b/src/document.h
@@ -1065,7 +1065,7 @@ struct Document {
             case A_CASESENSITIVESEARCH: {
                 sys->casesensitivesearch = !(sys->casesensitivesearch);
                 sys->cfg->Write(L"casesensitivesearch", sys->casesensitivesearch);
-                sys->frame->search(sys->searchstring);
+                this->Refresh();
                 return nullptr;
             }
 

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -1036,10 +1036,8 @@ struct MyFrame : wxFrame {
     }
 
     void OnSearch(wxCommandEvent &ce) {
-        return search(ce.GetString());
-    }
-
-    void search(wxString searchstring) {
+        wxString searchstring = ce.GetString();
+        sys->darkennonmatchingcells = searchstring.Len() != 0;
         sys->searchstring = searchstring;
         Document *doc = GetCurTab()->doc;
         doc->selected.g = nullptr;

--- a/src/system.h
+++ b/src/system.h
@@ -89,6 +89,7 @@ struct System {
     bool fswatch;
     bool autohtmlexport;
     bool casesensitivesearch;
+    bool darkennonmatchingcells;
 
     int sortcolumn, sortxs, sortdescending;
 
@@ -141,6 +142,7 @@ struct System {
           fswatch(true),
           autohtmlexport(false),
           casesensitivesearch(true),
+          darkennonmatchingcells(false),
           insidefiledialog(false) {
         static const wxDash glpattern[] = {1, 3};
         pen_gridlines.SetDashes(2, glpattern);
@@ -163,7 +165,6 @@ struct System {
         cfg->Read(L"fswatch", &fswatch, fswatch);
         cfg->Read(L"autohtmlexport", &autohtmlexport, autohtmlexport);
         cfg->Read(L"casesensitivesearch", &casesensitivesearch, casesensitivesearch);
-
         cfg->Read(L"defaultfontsize", &g_deftextsize, g_deftextsize);
 
         // fsw.Connect(wxID_ANY, wxID_ANY, wxEVT_FSWATCHER,

--- a/src/text.h
+++ b/src/text.h
@@ -177,6 +177,7 @@ struct Text {
         else
             return sys->searchstring.Len() && t.Lower().Find(sys->searchstring.Lower()) >= 0;
     }
+    
     int Render(Document *doc, int bx, int by, int depth, wxDC &dc, int &leftoffset,
                int maxcolwidth) {
         int ixs = 0, iys = 0;
@@ -197,12 +198,9 @@ struct Text {
         leftoffset = h;
         int i = 0;
         int lines = 0;
-        bool searchfound = IsInSearch();
         bool istag = cell->IsTag(doc);
         if (cell->tiny) {
-            if (searchfound)
-                dc.SetPen(*wxRED_PEN);
-            else if (filtered)
+            if (filtered)
                 dc.SetPen(*wxLIGHT_GREY_PEN);
             else if (istag)
                 dc.SetPen(*wxBLUE_PEN);
@@ -232,9 +230,7 @@ struct Text {
                     }
                 }
             } else {
-                if (searchfound)
-                    dc.SetTextForeground(*wxRED);
-                else if (filtered)
+                if (filtered)
                     dc.SetTextForeground(*wxLIGHT_GREY);
                 else if (istag)
                     dc.SetTextForeground(*wxBLUE);
@@ -243,7 +239,7 @@ struct Text {
                 int tx = bx + 2 + ixs;
                 int ty = by + lines * h;
                 dc.DrawText(curl, tx + g_margin_extra, ty + g_margin_extra);
-                if (searchfound || filtered || istag || cell->textcolor)
+                if (filtered || istag || cell->textcolor)
                     dc.SetTextForeground(*wxBLACK);
             }
             lines++;


### PR DESCRIPTION
This is the second iteration of a Pull Request for darkening non-matching cells in search.

- There is only one string search left (`IsInSearch()`). In order to achieve this, there is no extra check in the cell to color it red in case of match. Darkening the surrounding non-matching cells should be highlighting enough and this change bringes the advantage that the original cell color is not changed (e.g. tags, other text colors)