### PR TITLE
Jump to cell text end when entering the cell via F2

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -1370,12 +1370,13 @@ struct Document {
                 return nullptr;
 
             case A_ENTERCELL:
+            case A_ENTERCELL_JUMPTOEND:
             case A_PROGRESSCELL: {
                 if (!(c = selected.ThinExpand(this))) return OneCell();
                 if (selected.TextEdit()) {
                     selected.Cursor(this, (k==A_ENTERCELL ? A_DOWN : A_RIGHT), false, false, dc, true);
                 } else {
-                    selected.EnterEdit(this, 0, (int)c->text.t.Len());
+                    selected.EnterEdit(this, (k == A_ENTERCELL_JUMPTOEND) ? (int)c->text.t.Len() : 0, (int)c->text.t.Len());
                     DrawSelectMove(dc, selected, true);
                 }
                 return nullptr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -127,6 +127,7 @@ enum {
     A_CANCELEDIT,
     A_BROWSE,
     A_ENTERCELL,
+    A_ENTERCELL_JUMPTOEND,
     A_PROGRESSCELL, // see https://github.com/aardappel/treesheets/issues/139#issuecomment-544167524
     A_CELLCOLOR,
     A_TEXTCOLOR,

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -324,7 +324,7 @@ struct MyFrame : wxFrame {
             MyAppend(temenu, A_CEND, _(L"End of text\tCTRL+END"));
             temenu->AppendSeparator();
             MyAppend(temenu, A_ENTERCELL, _(L"Enter/exit text edit mode\tENTER"));
-            MyAppend(temenu, A_ENTERCELL, _(L"Enter/exit text edit mode\tF2"));
+            MyAppend(temenu, A_ENTERCELL_JUMPTOEND, _(L"Enter/exit text edit mode\tF2"));
             MyAppend(temenu, A_PROGRESSCELL, _(L"Enter/exit text edit to the right\tALT+ENTER"));
             MyAppend(temenu, A_CANCELEDIT, _(L"Cancel text edits\tESC"));
 


### PR DESCRIPTION
Instead of selecting the whole text to be overwritten when the cell is entered, set cursor to the text end. It might be worth a discussion which use case is more prominent: Overwriting cell text or appending to cell text?