### PR TITLE
Proposals for improving the search

### DIFF
--- a/src/myframe.h
+++ b/src/myframe.h
@@ -1052,8 +1052,13 @@ struct MyFrame : wxFrame {
     void OnSearchEnter(wxCommandEvent &ce) {
         TSCanvas *sw = GetCurTab();
         Document *doc = GetCurTab()->doc;
-        wxClientDC dc(sw);
-        doc->SearchNext(dc, false);
+        wxString searchstring = ce.GetString();
+        if (searchstring.Len() == 0) {
+            sw->SetFocus();
+        } else {
+            wxClientDC dc(sw);
+            doc->SearchNext(dc, false);
+        }
     }
 
     void ReFocus() {

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -1042,7 +1042,6 @@ struct MyFrame : wxFrame {
     void search(wxString searchstring) {
         sys->searchstring = searchstring;
         Document *doc = GetCurTab()->doc;
-        doc->selected.g = nullptr;
         if (doc->searchfilter)
             doc->SetSearchFilter(sys->searchstring.Len() != 0);
         else


### PR DESCRIPTION
Proposals:
- Selection should be kept when search is active (e.g. when the user changes the search term or has mistyped the search term, it may be more convenient to keep the selection)
- When pressing Enter in the Search text control with no search term, give back focus to the Canvas window.