### PR TITLE
Jump to the selection after first paint on canvas

### DIFF
--- a/src/mycanvas.h
+++ b/src/mycanvas.h
@@ -4,6 +4,7 @@ struct TSCanvas : public wxScrolledWindow {
 
     int mousewheelaccum;
     bool lastrmbwaswithctrl;
+    bool firstpaint;
 
     wxPoint lastmousepos;
 
@@ -13,7 +14,8 @@ struct TSCanvas : public wxScrolledWindow {
                            wxScrolledWindowStyle | wxWANTS_CHARS),
           mousewheelaccum(0),
           doc(nullptr),
-          lastrmbwaswithctrl(false) {
+          lastrmbwaswithctrl(false),
+          firstpaint(true) {
         SetBackgroundStyle(wxBG_STYLE_PAINT);
         SetBackgroundColour(*wxWHITE);
         DisableKeyboardScrolling();
@@ -40,6 +42,10 @@ struct TSCanvas : public wxScrolledWindow {
         #endif
         // DoPrepareDC(dc);
         doc->Draw(dc);
+        if (firstpaint) {
+            doc->ScrollOrZoom(dc);
+            firstpaint = false;
+        }
         // Display has been re-layouted, compute hover selection again.
         // TODO: lastmousepos doesn't seem correct anymore after a scroll operation in latest wxWidgets.
         /*


### PR DESCRIPTION
Use case: If the user opens the TreeSheets document, TreeSheets will jump to the selection.

Benefit: The user can continue right away at the place where the user stopped before.

Caveat: Tested on Windows and Linux, but only works on Linux so far (reason unknown).