### PR TITLE
Use wxPaintDC instead of wxBufferPaintDC on Windows

### DIFF
--- a/src/mycanvas.h
+++ b/src/mycanvas.h
@@ -28,16 +28,7 @@ struct TSCanvas : public wxScrolledWindow {
     }
 
     void OnPaint(wxPaintEvent &event) {
-        #ifdef __WXMAC__
-            wxPaintDC dc(this);
-        #elif __WXGTK__
-            wxPaintDC dc(this);
-        #else
-            auto sz = GetClientSize();
-            if (sz.GetX() <= 0 || sz.GetY() <= 0) return;
-            wxBitmap buffer(sz.GetX(), sz.GetY(), 24);
-            wxBufferedPaintDC dc(this, buffer);
-        #endif
+        wxPaintDC dc(this);
         // DoPrepareDC(dc);
         doc->Draw(dc);
         // Display has been re-layouted, compute hover selection again.


### PR DESCRIPTION
I tested on Windows 10. There seems to be no need for `wxBufferPaintDC` (any more).