### PR TITLE
Use device-independent pixels in MyFrame

### DIFF
--- a/src/myframe.h
+++ b/src/myframe.h
@@ -17,7 +17,7 @@ struct MyFrame : wxFrame {
     MyApp *app;
     wxFileSystemWatcher *watcher;
     bool watcherwaitingforuser;
-    double csf, csf_orig;
+    double csf = FromDIP(1.0); // TODO: functions using this attribute should be modified to handle device-independent pixels
     std::vector<std::string> scripts_in_menu;
     bool zenmode;
     ColorDropdown *celldd = nullptr;
@@ -121,37 +121,6 @@ struct MyFrame : wxFrame {
 
         app->AddTranslation(GetDataPath("translations"));
 
-        csf = GetContentScaleFactor();
-        wxLogMessage(L"content scale: %f", csf);
-        csf_orig = csf;
-        #ifdef __WXMSW__
-            // On Windows, I get csf == 1.25, as indicated in the display properties.
-            // With this factor set, bitmaps display. At their same physical sizes as when
-            // TreeSheets was a non-DPI-aware app, and extra resolution is used.
-        #endif
-        #ifdef __WXMAC__
-            // Typically csf == 2 on a retina mac. But on the mac, unlike Windows, image rendering
-            // *already* does scaling, and no way to turn that behavior off for now?
-            csf = 1.0;
-            // FIXME: This gives us low res images even though the display is capable of better!
-            // Apparently still not fixed: http://trac.wxwidgets.org/ticket/15808
-            // wxBitmap::CreateScaled could be the way to solve this, but it is not obvious
-            // how to use it, since you can't pass this scale to LoadFile etc. Could possibly
-            // blit it over via a MemoryDC?
-        #endif
-        #ifdef __WXGTK__
-            // On X11 platform, there is no scaling factor beside 1.0, but the DPI can be changed.
-
-            // On Wayland platform, there might be a scaling factor beside 1.0, 
-            // but the DPI is assumed to be a fixed value by default.
-
-            // If upscaling is active in Wayland compositors, the reported bitmap to paint on is downsized (and vice versa).
-            // The scaling is handled by the GTK toolkit and the Wayland compositor. 
-            // This is why csf should be set to 1.0 to let scaling be handled by the
-            // toolkit and compositor and not to be handled by TreeSheets itself.
-            csf = 1.0;
-        #endif
-
         wxInitAllImageHandlers();
 
         wxIconBundle icons;
@@ -184,7 +153,7 @@ struct MyFrame : wxFrame {
         line_sw.LoadFile(GetDataPath(L"images/render/line_sw.png"), wxBITMAP_TYPE_PNG);
         foldiconi.LoadFile(GetDataPath(L"images/nuvola/fold.png"));
         foldicon = wxBitmap(foldiconi);
-        ScaleBitmap(foldicon, csf / 3.0, foldicon);
+        ScaleBitmap(foldicon, FromDIP(1.0) / 3.0, foldicon);
 
         if (sys->singletray)
             tbi.Connect(wxID_ANY, wxEVT_TASKBAR_LEFT_UP,
@@ -667,7 +636,7 @@ struct MyFrame : wxFrame {
 
             wxString iconpath =
                 GetDataPath(iconset ? L"images/webalys/toolbar/" : L"images/nuvola/toolbar/");
-            auto sz = (iconset ? wxSize(18, 18) : wxSize(22, 22)) * csf;
+            auto sz = FromDIP(iconset ? wxSize(18, 18) : wxSize(22, 22));
             tb->SetToolBitmapSize(sz);
 
             double sc = iconset ? 1.0 : 22.0 / 48.0;
@@ -675,9 +644,7 @@ struct MyFrame : wxFrame {
             auto AddTBIcon = [&](const wxChar *name, int action, wxString file) {
                 wxBitmap bm;
                 if (bm.LoadFile(file, wxBITMAP_TYPE_PNG)) {
-                    auto ns = csf_orig * sc;
-                    ScaleBitmap(bm, ns, bm);
-                    MakeInternallyScaled(bm, tb->GetBackgroundColour(), csf_orig);
+                    ScaleBitmap(bm, sc, bm);
                     tb->AddTool(action, name, bm, bm, wxITEM_NORMAL, name);
                 }
             };
@@ -701,23 +668,23 @@ struct MyFrame : wxFrame {
             tb->AddSeparator();
             tb->AddControl(new wxStaticText(tb, wxID_ANY, _(L"Search ")));
             tb->AddControl(filter = 
-                new wxTextCtrl(tb, A_SEARCH, "", wxDefaultPosition, wxSize(80, 22) * csf, wxTE_PROCESS_ENTER));
+                new wxTextCtrl(tb, A_SEARCH, "", wxDefaultPosition, FromDIP(wxSize(80, 22)), wxTE_PROCESS_ENTER));
             AddTBIcon(_(L"Go to Next Search Result"), A_SEARCHNEXT, iconpath + L"search.png");
             SEPARATOR;
             tb->AddControl(new wxStaticText(tb, wxID_ANY, _(L"Replace ")));
             tb->AddControl(replaces =
-                new wxTextCtrl(tb, A_REPLACE, "", wxDefaultPosition, wxSize(60, 22) * csf));
+                new wxTextCtrl(tb, A_REPLACE, "", wxDefaultPosition, FromDIP(wxSize(60, 22))));
             tb->AddSeparator();
             tb->AddControl(new wxStaticText(tb, wxID_ANY, _(L"Cell ")));
-            celldd = new ColorDropdown(tb, A_CELLCOLOR, csf, 1);
+            celldd = new ColorDropdown(tb, A_CELLCOLOR, 1);
             tb->AddControl(celldd);
             SEPARATOR;
             tb->AddControl(new wxStaticText(tb, wxID_ANY, _(L"Text ")));
-            textdd = new ColorDropdown(tb, A_TEXTCOLOR, csf, 2);
+            textdd = new ColorDropdown(tb, A_TEXTCOLOR, 2);
             tb->AddControl(textdd);
             SEPARATOR;
             tb->AddControl(new wxStaticText(tb, wxID_ANY, _(L"Border ")));
-            borddd = new ColorDropdown(tb, A_BORDCOLOR, csf, 7);
+            borddd = new ColorDropdown(tb, A_BORDCOLOR, 7);
             tb->AddControl(borddd);
             tb->AddSeparator();
             tb->AddControl(new wxStaticText(tb, wxID_ANY, _(L"Image ")));

--- a/src/mywxtools.h
+++ b/src/mywxtools.h
@@ -67,21 +67,19 @@ struct ColorPopup : wxVListBoxComboPopup {
 };
 
 struct ColorDropdown : wxOwnerDrawnComboBox {
-    double csf;
 
-    ColorDropdown(wxWindow *parent, wxWindowID id, double _csf, int sel) {
-        csf = _csf;
+    ColorDropdown(wxWindow *parent, wxWindowID id, int sel) {
         wxArrayString as;
         as.Add(L"", sizeof(celltextcolors) / sizeof(uint));
-        Create(parent, id, L"", wxDefaultPosition, wxSize(44, 22) * csf, as,
+        Create(parent, id, L"", wxDefaultPosition, FromDIP(wxSize(44, 22)), as,
                wxCB_READONLY | wxCC_SPECIAL_DCLICK);
         SetPopupControl(new ColorPopup(this));
         SetSelection(sel);
         SetPopupMaxHeight(wxDisplay().GetGeometry().GetHeight() * 3 / 4);
     }
 
-    wxCoord OnMeasureItem(size_t item) const { return 22 * csf; }
-    wxCoord OnMeasureItemWidth(size_t item) const { return 40 * csf; }
+    wxCoord OnMeasureItem(size_t item) const { return FromDIP(22); }
+    wxCoord OnMeasureItemWidth(size_t item) const { return FromDIP(40); }
     void OnDrawBackground(wxDC &dc, const wxRect &rect, int item, int flags) const {
         DrawRectangle(dc, 0xFFFFFF, rect.x, rect.y, rect.width, rect.height);
     }
@@ -111,41 +109,37 @@ struct ImageDropdown : wxOwnerDrawnComboBox {
     // FIXME: delete these somewhere
     Vector<wxBitmap *> bitmaps_display;
     wxArrayString as;
-    double csf, csf_orig;
     const int image_space = 22;
 
     ImageDropdown(wxWindow *parent, wxString &path) {
-        csf = sys->frame->csf;
-        csf_orig = sys->frame->csf;
         wxString f = wxFindFirstFile(path + L"*.*");
         while (!f.empty()) {
             wxBitmap bm;
             if (bm.LoadFile(f, wxBITMAP_TYPE_PNG)) {
                 auto dbm = new wxBitmap();
-                ScaleBitmap(bm, csf_orig / dd_icon_res_scale, *dbm);
-                MakeInternallyScaled(*dbm, *wxWHITE, csf_orig);
+                ScaleBitmap(bm, FromDIP(1.0) / dd_icon_res_scale, *dbm);
                 bitmaps_display.push() = dbm;
                 as.Add(f);
             }
             f = wxFindNextFile();
         }
         Create(parent, A_DDIMAGE, L"", wxDefaultPosition,
-               wxSize(image_space * 2, image_space) * csf, as,
+               FromDIP(wxSize(image_space * 2, image_space)), as,
                wxCB_READONLY | wxCC_SPECIAL_DCLICK);
         SetPopupControl(new ImagePopup());
         SetSelection(0);
         SetPopupMaxHeight(wxDisplay().GetGeometry().GetHeight() * 3 / 4);
     }
 
-    wxCoord OnMeasureItem(size_t item) const { return image_space * csf; }
-    wxCoord OnMeasureItemWidth(size_t item) const { return image_space * csf; }
+    wxCoord OnMeasureItem(size_t item) const { return FromDIP(image_space); }
+    wxCoord OnMeasureItemWidth(size_t item) const { return FromDIP(image_space); }
     void OnDrawBackground(wxDC &dc, const wxRect &rect, int item, int flags) const {
         DrawRectangle(dc, 0xFFFFFF, rect.x, rect.y, rect.width, rect.height);
     }
 
     void OnDrawItem(wxDC &dc, const wxRect &rect, int item, int flags) const {
         auto bm = bitmaps_display[item];
-        sys->ImageDraw(bm, dc, rect.x + 3 * csf, rect.y + 3 * csf);
+        sys->ImageDraw(bm, dc, rect.x + FromDIP(3), rect.y + FromDIP(3));
     }
 };
 


### PR DESCRIPTION
Use the device-independent pixels to abstract away the problems of scaling on displays with different DPI. wxWidgets will handle the correct scaling.

Please refer to <https://docs.wxwidgets.org/3.2/overview_high_dpi.html> for more details about High DPI support in wxWidgets.

This targets mainly the toolbar that shall display correctly on High DPI displays.