### PR TITLE
Use DPIChangedEvent to redraw Document correctly

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -74,6 +74,7 @@ struct Document {
 
     bool redrawpending;
     bool firstdraw;
+    bool dpichanged;
 
     bool scaledviewingmode;
     double currentviewscale;
@@ -114,6 +115,7 @@ struct Document {
           blink(true),
           redrawpending(false),
           firstdraw(true),
+          dpichanged(false),
           scaledviewingmode(false),
           currentviewscale(1),
           editfilter(0),
@@ -541,6 +543,12 @@ struct Document {
     }
 
     void Draw(wxDC &dc) {
+        if(dpichanged) {
+            curdrawroot->ResetLayout();
+            curdrawroot->ResetChildren();
+            firstdraw = true;
+            dpichanged = false;
+        }
         redrawpending = false;
         dc.SetBackground(wxBrush(wxColor(Background())));
         dc.Clear();

--- a/src/myevents.h
+++ b/src/myevents.h
@@ -14,6 +14,7 @@ BEGIN_EVENT_TABLE(treesheets::MyFrame, wxFrame)
   EVT_ICONIZE(treesheets::MyFrame::OnIconize)
   EVT_AUINOTEBOOK_PAGE_CHANGED(wxID_ANY, treesheets::MyFrame::OnTabChange)
   EVT_AUINOTEBOOK_PAGE_CLOSE(wxID_ANY, treesheets::MyFrame::OnTabClose)
+  EVT_DPI_CHANGED(treesheets::MyFrame::OnDPIChanged)
 END_EVENT_TABLE()
 
 BEGIN_EVENT_TABLE(treesheets::MyApp, wxApp)

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -1096,6 +1096,13 @@ struct MyFrame : wxFrame {
         ReFocus();
     }
 
+    void OnDPIChanged(wxDPIChangedEvent &dce) {
+          if (nb) loop(i, nb->GetPageCount()) {
+                TSCanvas *p = (TSCanvas *)nb->GetPage(i);
+                p->doc->dpichanged = true;
+                }
+    }
+
     void OnIconize(wxIconizeEvent &me) {
         if (me.IsIconized()) {
             #ifndef __WXMAC__


### PR DESCRIPTION
Please refer to
<https://docs.wxwidgets.org/latest/classwx_d_p_i_changed_event.html> for the documentation on how to handle DPI change events on the MSW port.