### PR TITLE
Remove obsolete function MakeInternallyScaled()

### DIFF
--- a/src/mywxtools.h
+++ b/src/mywxtools.h
@@ -147,20 +147,3 @@ static void ScaleBitmap(const wxBitmap &src, double sc, wxBitmap &dest) {
     dest = wxBitmap(src.ConvertToImage().Scale(src.GetWidth() * sc, src.GetHeight() * sc,
                     wxIMAGE_QUALITY_HIGH));
 }
-
-static void MakeInternallyScaled(wxBitmap &bm, const wxColour bg, double sc) {
-    #ifdef __WXMAC__
-        // What a mess.. is there a simpler way?
-        wxBitmap sbm;
-        sbm.CreateScaled(bm.GetWidth() / sc, bm.GetHeight() / sc, bm.GetDepth(), sc);
-        wxMemoryDC sdc(sbm);
-        //wxMemoryDC dc(bm);
-        // FIXME: this should really be transparent.
-        sdc.SetBackground(wxBrush(bg));
-        sdc.Clear();
-        //sdc.Blit(0, 0, bm.GetWidth(), bm.GetHeight(), &dc, 0, 0, wxCOPY);
-        sdc.SetUserScale(1.0 / sc, 1.0 / sc);
-        sdc.DrawBitmap(bm, wxPoint(0, 0));
-        bm = sbm;
-    #endif
-}

--- a/src/system.h
+++ b/src/system.h
@@ -39,8 +39,6 @@ struct Image {
     wxBitmap &Display() {
         if (!bm_display.IsOk()) {
             ScaleBitmap(bm_orig, 1.0 / display_scale * sys->frame->csf, bm_display);
-            // FIXME: this won't work because it will ignore the cell's bg color.
-            //MakeInternallyScaled(bm_display, *wxWHITE, sys->frame->csf_orig);
         }
         last_display = wxGetLocalTime();
         return bm_display;


### PR DESCRIPTION
As wxWidgets handles the correct drawing depending on the set DPI by using device-independent pixels, the function MakeInternallyScaled() becomes obsolete. This commit removes the function.