### PR TITLE
Leave search when Escape key is pressed

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -1080,7 +1080,7 @@ struct Document {
             }
 
             case A_SEARCHNEXT: {
-                return SearchNext(dc, true);
+                return SearchNext(dc, false);
             }
 
             case A_CASESENSITIVESEARCH: {

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -851,6 +851,7 @@ struct MyFrame : wxFrame {
 
     void OnMenu(wxCommandEvent &ce) {
         wxTextCtrl *tc;
+        TSCanvas *sw = GetCurTab();
         if (((tc = filter) && filter == wxWindow::FindFocus()) ||
             ((tc = replaces) && replaces == wxWindow::FindFocus())) {
             // FIXME: have to emulate this behavior because menu always captures these events (??)
@@ -889,9 +890,9 @@ struct MyFrame : wxFrame {
                 case A_HOME: tc->SetSelection(0, 0); return;
                 case A_END: tc->SetSelection(1000, 1000); return;
                 case A_SELALL: tc->SetSelection(0, 1000); return;
+                case A_CANCELEDIT: tc->Clear(); sw->SetFocus(); return;
             }
         }
-        TSCanvas *sw = GetCurTab();
         wxClientDC dc(sw);
         sw->DoPrepareDC(dc);
         sw->doc->ShiftToCenter(dc);


### PR DESCRIPTION
This PR uses the existing workaround with menu events processed by OnMenu.
Escape key is bound to either action A_ENTERCELL or A_ENTERGRID, so these are used as triggers to clear the search control.

For now, I would recommend to not use the wxSearchCtrl because it is a native widget for wxGTK and wxGTK but not in wxMSW, leading to different behaviour on events.