### PR TITLE
Focus after search is cleared

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -1092,6 +1092,7 @@ struct Document {
 
             case A_CLEARSEARCH: {
                 sys->frame->filter->Clear();
+                sw->SetFocus();
                 return nullptr;
             }
 


### PR DESCRIPTION
Just one small tweak for consistent behaviour with escape key pressed and toolbar clear search button clicked
(after both triggered focus should go to the canvas)