### PR TITLE
Adjust tab height of notebook in case DPI changed

### DIFF
--- a/src/myframe.h
+++ b/src/myframe.h
@@ -1066,9 +1066,12 @@ struct MyFrame : wxFrame {
     }
 
     void OnDPIChanged(wxDPIChangedEvent &dce) {
-        if (nb) loop(i, nb->GetPageCount()) {
-            TSCanvas *p = (TSCanvas *)nb->GetPage(i);
-            p->doc->dpichanged = true;
+        if (nb) {
+            loop(i, nb->GetPageCount()) {
+                TSCanvas *p = (TSCanvas *)nb->GetPage(i);
+                p->doc->dpichanged = true;
+            }
+            nb->SetTabCtrlHeight(-1);
         }
         Update();
     }


### PR DESCRIPTION
The Tab Control height does not get resized automatically so resize it manually in case the DPI changed

Please refer to <https://docs.wxwidgets.org/latest/classwx_aui_notebook.html#aa784a41316fc5bde864d90ae0a3dac8a> for more details.