### PR TITLE
Rescale images in image dropdown in case DPI changed

### DIFF
--- a/src/myframe.h
+++ b/src/myframe.h
@@ -23,6 +23,7 @@ struct MyFrame : wxFrame {
     ColorDropdown *celldd = nullptr;
     ColorDropdown *textdd = nullptr;
     ColorDropdown *borddd = nullptr;
+    wxString imagepath;
     
     wxString GetDocPath(const wxString &relpath) {
         std::filesystem::path candidatePaths[] = {
@@ -93,7 +94,6 @@ struct MyFrame : wxFrame {
           watcher(nullptr),
           zenmode(false) {
         sys->frame = this;
-
         exepath_ = wxFileName(exename).GetPath();
         #ifdef __WXMAC__
         int cut = exepath_.Find("/MacOS");
@@ -154,6 +154,8 @@ struct MyFrame : wxFrame {
         foldiconi.LoadFile(GetDataPath(L"images/nuvola/fold.png"));
         foldicon = wxBitmap(foldiconi);
         ScaleBitmap(foldicon, FromDIP(1.0) / 3.0, foldicon);
+
+        imagepath = GetDataPath("images/nuvola/dropdown/");
 
         if (sys->singletray)
             tbi.Connect(wxID_ANY, wxEVT_TASKBAR_LEFT_UP,
@@ -689,7 +691,6 @@ struct MyFrame : wxFrame {
             tb->AddControl(borddd);
             tb->AddSeparator();
             tb->AddControl(new wxStaticText(tb, wxID_ANY, _(L"Image ")));
-            wxString imagepath = GetDataPath("images/nuvola/dropdown/");
             idd = new ImageDropdown(tb, imagepath);
             tb->AddControl(idd);
             tb->Realize();
@@ -1073,6 +1074,7 @@ struct MyFrame : wxFrame {
             }
             nb->SetTabCtrlHeight(-1);
         }
+        idd->FillBitmapVector(imagepath);
         Update();
     }
 

--- a/src/mywxtools.h
+++ b/src/mywxtools.h
@@ -112,17 +112,7 @@ struct ImageDropdown : wxOwnerDrawnComboBox {
     const int image_space = 22;
 
     ImageDropdown(wxWindow *parent, wxString &path) {
-        wxString f = wxFindFirstFile(path + L"*.*");
-        while (!f.empty()) {
-            wxBitmap bm;
-            if (bm.LoadFile(f, wxBITMAP_TYPE_PNG)) {
-                auto dbm = new wxBitmap();
-                ScaleBitmap(bm, FromDIP(1.0) / dd_icon_res_scale, *dbm);
-                bitmaps_display.push() = dbm;
-                as.Add(f);
-            }
-            f = wxFindNextFile();
-        }
+        FillBitmapVector(path);
         Create(parent, A_DDIMAGE, L"", wxDefaultPosition,
                FromDIP(wxSize(image_space * 2, image_space)), as,
                wxCB_READONLY | wxCC_SPECIAL_DCLICK);
@@ -140,6 +130,21 @@ struct ImageDropdown : wxOwnerDrawnComboBox {
     void OnDrawItem(wxDC &dc, const wxRect &rect, int item, int flags) const {
         auto bm = bitmaps_display[item];
         sys->ImageDraw(bm, dc, rect.x + FromDIP(3), rect.y + FromDIP(3));
+    }
+
+    void FillBitmapVector(wxString &path) {
+        if (!bitmaps_display.empty()) bitmaps_display.setsize(0);
+        wxString f = wxFindFirstFile(path + L"*.*");
+        while (!f.empty()) {
+            wxBitmap bm;
+            if (bm.LoadFile(f, wxBITMAP_TYPE_PNG)) {
+                auto dbm = new wxBitmap();
+                ScaleBitmap(bm, FromDIP(1.0) / dd_icon_res_scale, *dbm);
+                bitmaps_display.push() = dbm;
+                as.Add(f);
+            }
+            f = wxFindNextFile();
+        }
     }
 };
 


### PR DESCRIPTION
In order to refill the vector with the bitmaps when the DPI changes, isolate the corresponding code block into a generic member function called FillBitmapVector. This commit also places the variable imagepath into the MyFrame class so that it is accessible for the function that handles the DPI change event