### PR TITLE
Copy HTML to clipboard

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -1279,14 +1279,30 @@ struct Document {
                     returnmessage = CopyImageToClipboard(c);
                 } else {
                     if (wxTheClipboard->Open()) {
-                        wxString s;
+                        wxString s, html;
                         if (k == A_COPYCT) {
                             loopallcellssel(c, true) if (c->text.t.Len()) s += c->text.t + " ";
                         } else {
                             s = selected.g->ConvertToText(selected, 0, A_EXPTEXT, this);
                         }
                         sys->clipboardcopy = s;
-                        wxTheClipboard->SetData(new wxTextDataObject(s));
+                        html = selected.g->ConvertToText(selected, 0, A_EXPHTMLT, this);
+                        wxDataObjectComposite *copyobj = new wxDataObjectComposite();
+                        auto *htmlobj = 
+                        // wxGTK crashes when the HTML Data Object is requested
+                        // so workaround this issue with a custom data object
+                        #ifdef __WXGTK__
+                            new wxCustomDataObject(wxDF_HTML);
+                        htmlobj->SetData(html.Len(), html);
+                        #else
+                            new wxHTMLDataObject(html);
+                        #endif
+                        copyobj->Add(htmlobj);
+                        // wxGTK under Wayland fails to offer multiple data objects.
+                        // Instead, the last one added to the composite data object
+                        // will be offered under wxGTK/Wayland.
+                        copyobj->Add(new wxTextDataObject(s), true);
+                        wxTheClipboard->SetData(copyobj);
                         wxTheClipboard->Close();
                         returnmessage = _(L"Text copied to clipboard");
                     }


### PR DESCRIPTION
Create a composite data object that is placed to the clipboard.

The composite data object consists of
- a data object for HTML, either
  - a custom data object in wxGTK containing the HTML string or
  - a HTML data object in other toolkits (MSW, OSX) and
- a plain text data object (string).

Please note that the HTML data is within a custom data object for wxGTK as a HTML data object keeps causing a buffer overflow (wxWidgets implementation) when one tries to paste from the clipboard.

The HTML data object is marked as prefered.