### PR TITLE
Color search box

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -1089,6 +1089,7 @@ struct Document {
                     (sys->casesensitivesearch) ? 
                         sys->frame->filter->GetValue() : 
                         sys->frame->filter->GetValue().Lower();
+                sys->frame->SetSearchTextBoxBackgroundColour();
                 this->Refresh();
                 return nullptr;
             }

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -24,6 +24,7 @@ struct MyFrame : wxFrame {
     ColorDropdown *textdd = nullptr;
     ColorDropdown *borddd = nullptr;
     wxString imagepath;
+    bool searchmatchfound;
     
     wxString GetDocPath(const wxString &relpath) {
         std::filesystem::path candidatePaths[] = {
@@ -92,7 +93,8 @@ struct MyFrame : wxFrame {
           app(_app),
           watcherwaitingforuser(false),
           watcher(nullptr),
-          zenmode(false) {
+          zenmode(false),
+          searchmatchfound(false) {
         sys->frame = this;
         exepath_ = wxFileName(exename).GetPath();
         #ifdef __WXMAC__
@@ -817,6 +819,7 @@ struct MyFrame : wxFrame {
     void OnTabChange(wxAuiNotebookEvent &nbe) {
         TSCanvas *sw = (TSCanvas *)nb->GetPage(nbe.GetSelection());
         sw->Status();
+        SetSearchTextBoxBackgroundColour();
         sys->TabChange(sw->doc);
     }
 
@@ -1010,10 +1013,20 @@ struct MyFrame : wxFrame {
         }
     }
 
+    void SetSearchTextBoxBackgroundColour(bool found = false) {
+        if(found != searchmatchfound) {
+            searchmatchfound = !searchmatchfound;
+            filter->SetBackgroundColour(found ? *wxGREEN : wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX));
+            filter->SetForegroundColour(found ? *wxBLACK : wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXTEXT));
+            filter->Refresh();
+        }
+    }
+
     void OnSearch(wxCommandEvent &ce) {
         wxString searchstring = ce.GetString();
         sys->darkennonmatchingcells = searchstring.Len() != 0;
         sys->searchstring = (sys->casesensitivesearch) ? searchstring : searchstring.Lower();
+        SetSearchTextBoxBackgroundColour();
         Document *doc = GetCurTab()->doc;
         if (doc->searchfilter)
             doc->SetSearchFilter(sys->searchstring.Len() != 0);

--- a/src/text.h
+++ b/src/text.h
@@ -172,10 +172,20 @@ struct Text {
     }
 
     bool IsInSearch() {
-        if(sys->casesensitivesearch)
-            return sys->searchstring.Len() && t.Find(sys->searchstring) >= 0;
-        else
-            return sys->searchstring.Len() && t.Lower().Find(sys->searchstring) >= 0;
+        wxString *text;
+        wxString lowert;
+        if(sys->casesensitivesearch) {
+            text = &t;
+        } else {
+            lowert = t.Lower();
+            text = &lowert;
+        }
+
+        if(sys->searchstring.Len() && text->Find(sys->searchstring) >= 0) {
+            sys->frame->SetSearchTextBoxBackgroundColour(true);
+            return true;
+        }
+        return false;
     }
     
     int Render(Document *doc, int bx, int by, int depth, wxDC &dc, int &leftoffset,


### PR DESCRIPTION
- When search term is found, the background of the search text control turns green. Otherwise, use the system default color.

Small correction

- Share the match condition for case (in)sensitivity