### PR TITLE
Copy selection as Bitmap to clipboard

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -241,6 +241,7 @@ enum {
     A_DEFBGCOL,
     A_THINSELC,
     A_COPYCT,
+    A_COPYBM,
     A_MINISIZE,
     A_CUSTKEY,
     A_AUTOEXPORT,

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -383,6 +383,7 @@ struct MyFrame : wxFrame {
             editmenu = new wxMenu();
             MyAppend(editmenu, A_CUT, _(L"Cu&t\tCTRL+x"));
             MyAppend(editmenu, A_COPY, _(L"&Copy\tCTRL+c"));
+            MyAppend(editmenu, A_COPYBM, _(L"&Copy as Bitmap\tCTRL+ALT+c"));
             MyAppend(editmenu, A_COPYCT, _(L"Copy As Continuous Text"));
             MyAppend(editmenu, A_PASTE, _(L"&Paste\tCTRL+v"));
             MyAppend(editmenu, A_PASTESTYLE, _(L"Paste Style Only\tCTRL+SHIFT+v"),


### PR DESCRIPTION
This adds the rendered subbitmap of the selection to the clipboard data composite object.

This enables to copy the bitmap to programs dealing with bitmaps, e.g. image manipulation programs or journals.