### PR TITLE
Correct wxFileSelectorDefaultWildcardStr

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -1668,7 +1668,7 @@ struct Document {
                         if(!oimgfn) { // first encounter
                             oimgfn = ::wxFileSelector(
                                 _(L"Choose image file to save:"), L"", L"", L"png|jpg",
-                                 L"PNG file (*.png)|JPG file (*.jpg)|All Files (*.*)|*.*|",
+                                 L"PNG file (*.png)|*.png|JPEG file (*.jpg)|*.jpg|All Files (*.*)|*.*",
                                  wxFD_SAVE | wxFD_OVERWRITE_PROMPT | wxFD_CHANGE_DIR);
                             if (oimgfn.empty()) return _(L"Save cancelled.");
                             counterpos = oimgfn.find_last_of(".");


### PR DESCRIPTION
The wildcard string did not match the specification and unintended things happened. This should fix this.
Specification: https://docs.wxwidgets.org/trunk/group__group__funcmacro__dialog.html#ga920582bc0fbd96fcc26abb6fd698d90b