### PR TITLE
Add clang-tidy check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ target_include_directories(lobster PUBLIC lobster/include lobster/src lobster/ex
 add_library(lobster-impl STATIC src/lobster_impl.cpp)
 target_link_libraries(lobster-impl PRIVATE lobster)
 
+set(CMAKE_CXX_CLANG_TIDY clang-tidy -checks=*)
 add_executable(
     treesheets
     src/main.cpp


### PR DESCRIPTION
When clang-tidy is installed, use the linter.