### PR TITLE
Add virtual destructor for ScriptInterface

### DIFF
--- a/src/script_interface.h
+++ b/src/script_interface.h
@@ -32,6 +32,7 @@ struct ScriptInterface {
     virtual void SetWindowSize(int width, int height) = 0;
     virtual std::string GetFileNameFromUser(bool is_save) = 0;
     virtual std::string GetFileName() = 0;
+    virtual ~ScriptInterface() {};
 };
 
 typedef int64_t(*ScriptLoader)(std::string_view absfilename, std::string *dest, int64_t start,


### PR DESCRIPTION
In the case of a dynamic object of TreeSheetsScriptImpl being destructed where it differs from its static type (base class ScriptInterface), destruct properly by adding the virtual destructor to the base class.