### PR TITLE
Initialize memory input stream directly with buffer data

### DIFF
--- a/src/system.h
+++ b/src/system.h
@@ -655,10 +655,8 @@ struct System {
     }
 
     wxImage ConvertBufferToWxImage(vector<uint8_t> &pidv, wxBitmapType bmt) {
-        wxMemoryOutputStream mos(pidv.data(), pidv.size());
-        wxMemoryInputStream mis(mos);
-        wxImage im;
-        im.LoadFile(mis, bmt);
+        wxMemoryInputStream mis(pidv.data(), pidv.size());
+        wxImage im(mis, bmt);
         return im;
     }
 


### PR DESCRIPTION
- Save the extra memory output stream
- Intialize wxImage directly with the memory input stream