### PR TITLE
Use Selection constructor with default arguments

### DIFF
--- a/src/selection.h
+++ b/src/selection.h
@@ -8,8 +8,7 @@ class Selection {
     int cursor, cursorend;
     int firstdx, firstdy;
 
-    Selection() { memset(this, 0, sizeof(Selection)); }
-    Selection(Grid *_g, int _x, int _y, int _xs, int _ys)
+    Selection(Grid *_g = nullptr, int _x = 0, int _y = 0, int _xs = 0, int _ys = 0)
         : g(_g),
           x(_x),
           y(_y),


### PR DESCRIPTION
This fixes the case where the member variables are not properly initialized in case of Selection().

This manifested in the copied HTML string when only one cell was selected because s.x was not properly initialized (`<tr>` tag was missing).