### PR TITLE
Use vector directly for hash computation

### DIFF
--- a/src/system.h
+++ b/src/system.h
@@ -622,7 +622,7 @@ struct System {
     }
 
     int AddImageToList(double sc, vector<uint8_t> &&idv, char iti) {
-        auto hash = FNV1A64(string_view((char *)idv.data(), idv.size()));
+        auto hash = FNV1A64(idv);
         loopv(i, imagelist) {
             if (imagelist[i]->hash == hash) return i;
         }

--- a/src/tools.h
+++ b/src/tools.h
@@ -246,19 +246,19 @@ inline void __cdecl operator delete[](void *p, const char *fn, int l) {
 
 
 
-inline uint32_t FNV1A32(std::string_view s) {
+inline uint32_t FNV1A32(std::vector<uint8_t> &vec) {
     uint32_t hash = 0x811C9DC5;
-    for (auto c : s) {
-        hash ^= (uint8_t)c;
+    for (uint8_t c : vec) {
+        hash ^= c;
         hash *= 0x01000193;
     }
     return hash;
 }
 
-inline uint64_t FNV1A64(std::string_view s) {
+inline uint64_t FNV1A64(std::vector<uint8_t> &vec) {
     uint64_t hash = 0xCBF29CE484222325;
-    for (auto c : s) {
-        hash ^= (uint8_t)c;
+    for (uint8_t c : vec) {
+        hash ^= c;
         hash *= 0x100000001B3;
     }
     return hash;


### PR DESCRIPTION
When hash the complete dataset, do not add extra
type conversation to string_view