### PR TITLE
Explicitly prepend std:: to STL vector

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -880,7 +880,7 @@ struct Document {
                     // Always convert to PNG file format because wxWidgets has trouble dealing with other 
                     // image file formats in clipboard (especially for pasting).
                     wxImage imi = sys->ConvertBufferToWxImage(im->image_data, imagetypes.at(im->image_type).first);
-                    vector<uint8_t> idv = sys->ConvertWxImageToBuffer(imi, wxBITMAP_TYPE_PNG);
+                    std::vector<uint8_t> idv = sys->ConvertWxImageToBuffer(imi, wxBITMAP_TYPE_PNG);
                     image->SetData(idv.size(), idv.data());
                 }
                 wxTheClipboard->SetData(image);
@@ -2029,7 +2029,7 @@ struct Document {
                 if (dataobji->GetBitmap().GetRefData() != wxNullBitmap.GetRefData()) {
                     c->AddUndo(this);
                     wxImage im = dataobji->GetBitmap().ConvertToImage();
-                    vector<uint8_t> idv = sys->ConvertWxImageToBuffer(im, wxBITMAP_TYPE_PNG);
+                    std::vector<uint8_t> idv = sys->ConvertWxImageToBuffer(im, wxBITMAP_TYPE_PNG);
                     SetImageBM(c, std::move(idv), sys->frame->csf);
                     dataobji->SetBitmap(wxNullBitmap);
                     c->Reset();
@@ -2209,7 +2209,7 @@ struct Document {
         selected.g->ColorChange(this, which, col, selected);
     }
 
-    void SetImageBM(Cell *c, vector<uint8_t> &&idv, double sc) {
+    void SetImageBM(Cell *c, std::vector<uint8_t> &&idv, double sc) {
         c->text.image = sys->imagelist[sys->AddImageToList(sc, std::move(idv), 'I')];
     }
 
@@ -2217,7 +2217,7 @@ struct Document {
         if (fn.empty()) return false;
         wxImage im;
         if (!im.LoadFile(fn)) return false;
-        vector<uint8_t> idv = sys->ConvertWxImageToBuffer(im, wxBITMAP_TYPE_PNG);
+        std::vector<uint8_t> idv = sys->ConvertWxImageToBuffer(im, wxBITMAP_TYPE_PNG);
         SetImageBM(c, std::move(idv), sc);
         c->Reset();
         return true;

--- a/src/system.h
+++ b/src/system.h
@@ -1,5 +1,5 @@
 struct Image {
-    vector<uint8_t> image_data;
+    std::vector<uint8_t> image_data;
     char image_type;
     wxBitmap bm_display;
 
@@ -16,7 +16,7 @@ struct Image {
     long last_display = 0;
     int pixel_width = 0;
 
-    Image(uint64_t _hash, double _sc, vector<uint8_t> &&idv, char iti)
+    Image(uint64_t _hash, double _sc, std::vector<uint8_t> &&idv, char iti)
         : hash(_hash), display_scale(_sc), image_data(std::move(idv)), image_type(iti) {}
 
 
@@ -306,7 +306,7 @@ struct System {
                         wxBitmapType imt = mapitem->second.first;
                         if (versionlastloaded < 9) dis.ReadString();
                         double sc = versionlastloaded >= 19 ? dis.ReadDouble() : 1.0;
-                        vector<uint8_t> image_data;
+                        std::vector<uint8_t> image_data;
                         off_t beforeimage = fis.TellI();
                         wxImage im;
                         bool ok = im.LoadFile(fis);
@@ -621,7 +621,7 @@ struct System {
         return (int)as.size();
     }
 
-    int AddImageToList(double sc, vector<uint8_t> &&idv, char iti) {
+    int AddImageToList(double sc, std::vector<uint8_t> &&idv, char iti) {
         auto hash = FNV1A64(idv);
         loopv(i, imagelist) {
             if (imagelist[i]->hash == hash) return i;
@@ -641,8 +641,8 @@ struct System {
     }
 
 
-    vector<uint8_t> ConvertWxImageToBuffer(const wxImage &im, wxBitmapType bmt) {
-        vector<uint8_t> pidv;
+    std::vector<uint8_t> ConvertWxImageToBuffer(const wxImage &im, wxBitmapType bmt) {
+        std::vector<uint8_t> pidv;
         wxMemoryOutputStream mos(NULL, 0);
         im.SaveFile(mos, bmt);
         auto sz = mos.TellO();
@@ -651,13 +651,13 @@ struct System {
         return pidv;
     }
 
-    wxImage ConvertBufferToWxImage(vector<uint8_t> &pidv, wxBitmapType bmt) {
+    wxImage ConvertBufferToWxImage(std::vector<uint8_t> &pidv, wxBitmapType bmt) {
         wxMemoryInputStream mis(pidv.data(), pidv.size());
         wxImage im(mis, bmt);
         return im;
     }
 
-    wxBitmap ConvertBufferToWxBitmap(vector<uint8_t> &pidv, wxBitmapType bmt) {
+    wxBitmap ConvertBufferToWxBitmap(std::vector<uint8_t> &pidv, wxBitmapType bmt) {
         wxImage im = ConvertBufferToWxImage(pidv, bmt);
         wxBitmap bm(im, 32);
         return bm;


### PR DESCRIPTION
Avoid confusion with Vector