### PR TITLE
Introduce ThreadPool and use it for Display()

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -879,13 +879,13 @@ struct Document {
                 } else {
                     // Always convert to PNG file format because wxWidgets has trouble dealing with other 
                     // image file formats in clipboard (especially for pasting).
-                    wxImage imi = sys->ConvertBufferToWxImage(im->image_data, imagetypes.at(im->image_type).first);
-                    vector<uint8_t> idv = sys->ConvertWxImageToBuffer(imi, wxBITMAP_TYPE_PNG);
+                    wxImage imi = ConvertBufferToWxImage(im->image_data, imagetypes.at(im->image_type).first);
+                    vector<uint8_t> idv = ConvertWxImageToBuffer(imi, wxBITMAP_TYPE_PNG);
                     image->SetData(idv.size(), idv.data());
                 }
                 wxTheClipboard->SetData(image);
                 #else
-                wxBitmap bm = sys->ConvertBufferToWxBitmap(im->image_data, imagetypes.at(im->image_type).first);
+                wxBitmap bm = ConvertBufferToWxBitmap(im->image_data, imagetypes.at(im->image_type).first);
                 wxTheClipboard->SetData(new wxBitmapDataObject(bm));
                 #endif
             }
@@ -1738,8 +1738,8 @@ struct Document {
                         switch(k) {
                             case A_SAVE_AS_JPEG: {
                                 if(c->text.image->image_type == 'I') {
-                                    wxImage im = sys->ConvertBufferToWxImage(c->text.image->image_data, wxBITMAP_TYPE_PNG);
-                                    c->text.image->image_data = sys->ConvertWxImageToBuffer(im, wxBITMAP_TYPE_JPEG);
+                                    wxImage im = ConvertBufferToWxImage(c->text.image->image_data, wxBITMAP_TYPE_PNG);
+                                    c->text.image->image_data = ConvertWxImageToBuffer(im, wxBITMAP_TYPE_JPEG);
                                     c->text.image->image_type = 'J';
                                 }
                                 break;
@@ -1747,8 +1747,8 @@ struct Document {
                             case A_SAVE_AS_PNG:
                             default: {
                                 if(c->text.image->image_type == 'J') {
-                                    wxImage im = sys->ConvertBufferToWxImage(c->text.image->image_data, wxBITMAP_TYPE_JPEG);
-                                    c->text.image->image_data = sys->ConvertWxImageToBuffer(im, wxBITMAP_TYPE_PNG);
+                                    wxImage im = ConvertBufferToWxImage(c->text.image->image_data, wxBITMAP_TYPE_JPEG);
+                                    c->text.image->image_data = ConvertWxImageToBuffer(im, wxBITMAP_TYPE_PNG);
                                     c->text.image->image_type = 'I';
                                 }
                                 break;
@@ -2029,7 +2029,7 @@ struct Document {
                 if (dataobji->GetBitmap().GetRefData() != wxNullBitmap.GetRefData()) {
                     c->AddUndo(this);
                     wxImage im = dataobji->GetBitmap().ConvertToImage();
-                    vector<uint8_t> idv = sys->ConvertWxImageToBuffer(im, wxBITMAP_TYPE_PNG);
+                    vector<uint8_t> idv = ConvertWxImageToBuffer(im, wxBITMAP_TYPE_PNG);
                     SetImageBM(c, std::move(idv), sys->frame->csf);
                     dataobji->SetBitmap(wxNullBitmap);
                     c->Reset();
@@ -2217,7 +2217,7 @@ struct Document {
         if (fn.empty()) return false;
         wxImage im;
         if (!im.LoadFile(fn)) return false;
-        vector<uint8_t> idv = sys->ConvertWxImageToBuffer(im, wxBITMAP_TYPE_PNG);
+        vector<uint8_t> idv = ConvertWxImageToBuffer(im, wxBITMAP_TYPE_PNG);
         SetImageBM(c, std::move(idv), sc);
         c->Reset();
         return true;

--- a/src/mywxtools.h
+++ b/src/mywxtools.h
@@ -152,3 +152,24 @@ static void ScaleBitmap(const wxBitmap &src, double sc, wxBitmap &dest) {
     dest = wxBitmap(src.ConvertToImage().Scale(src.GetWidth() * sc, src.GetHeight() * sc,
                     wxIMAGE_QUALITY_HIGH));
 }
+
+static vector<uint8_t> ConvertWxImageToBuffer(const wxImage &im, wxBitmapType bmt) {
+    wxMemoryOutputStream mos(NULL, 0);
+    im.SaveFile(mos, bmt);
+    auto sz = mos.TellO();
+    vector<uint8_t> buf(sz);
+    mos.CopyTo(buf.data(), sz);
+    return buf;
+}
+
+static wxImage ConvertBufferToWxImage(vector<uint8_t> &buf, wxBitmapType bmt) {
+    wxMemoryInputStream mis(buf.data(), buf.size());
+    wxImage im(mis, bmt);
+    return im;
+}
+
+static wxBitmap ConvertBufferToWxBitmap(vector<uint8_t> &buf, wxBitmapType bmt) {
+    wxImage im = ConvertBufferToWxImage(buf, bmt);
+    wxBitmap bm(im, 32);
+    return bm;
+}

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -70,7 +70,6 @@
 WX_DECLARE_STRING_HASH_MAP(bool, wxHashMapBool);
 
 #include <new>
-
 #include <vector>
 #include <array>
 #include <string>
@@ -78,14 +77,19 @@ WX_DECLARE_STRING_HASH_MAP(bool, wxHashMapBool);
 #include <map>
 #include <algorithm>
 #include <memory>
-
+#include <queue>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <future>
+#include <functional>
+#include <stdexcept>
 #include <filesystem>
 #include <utility>
-
 #include <locale>
-
 #include <sstream>
 
+#include "threadpool.h"
 #include "tools.h"
 
 

--- a/src/system.h
+++ b/src/system.h
@@ -24,9 +24,9 @@ struct Image {
         auto mapitem = imagetypes.find(image_type);
         if (mapitem == imagetypes.end()) return;
         wxBitmapType it = mapitem->second.first;
-        wxImage im = sys->ConvertBufferToWxImage(image_data, it);
+        wxImage im = ConvertBufferToWxImage(image_data, it);
         im.Rescale(im.GetWidth() * sc, im.GetHeight() * sc);
-        image_data = sys->ConvertWxImageToBuffer(im, it);
+        image_data = ConvertWxImageToBuffer(im, it);
         bm_display = wxNullBitmap;
     }
 
@@ -48,7 +48,7 @@ struct Image {
             auto mapitem = imagetypes.find(image_type);
             if (mapitem == imagetypes.end()) return wxNullBitmap;
             wxBitmapType it = mapitem->second.first;
-            wxBitmap bm = sys->ConvertBufferToWxBitmap(image_data, it);
+            wxBitmap bm = ConvertBufferToWxBitmap(image_data, it);
             pixel_width = bm.GetWidth();
             ScaleBitmap(bm, 1.0 / display_scale * sys->frame->csf, bm_display);
         }
@@ -652,27 +652,5 @@ struct System {
 
     void ImageDraw(wxBitmap *bm, wxDC &dc, int x, int y) {
         dc.DrawBitmap(*bm, x, y);
-    }
-
-
-    vector<uint8_t> ConvertWxImageToBuffer(const wxImage &im, wxBitmapType bmt) {
-        wxMemoryOutputStream mos(NULL, 0);
-        im.SaveFile(mos, bmt);
-        auto sz = mos.TellO();
-        vector<uint8_t> pidv(sz);
-        mos.CopyTo(pidv.data(), sz);
-        return pidv;
-    }
-
-    wxImage ConvertBufferToWxImage(vector<uint8_t> &pidv, wxBitmapType bmt) {
-        wxMemoryInputStream mis(pidv.data(), pidv.size());
-        wxImage im(mis, bmt);
-        return im;
-    }
-
-    wxBitmap ConvertBufferToWxBitmap(vector<uint8_t> &pidv, wxBitmapType bmt) {
-        wxImage im = ConvertBufferToWxImage(pidv, bmt);
-        wxBitmap bm(im, 32);
-        return bm;
     }
 };

--- a/src/threadpool.h
+++ b/src/threadpool.h
@@ -1,0 +1,82 @@
+class ThreadPool {
+public:
+    ThreadPool(size_t);
+    template<class F, class... Args>
+    auto enqueue(F&& f, Args&&... args)
+        -> std::future<typename std::invoke_result<F, Args...>::type>;
+    ~ThreadPool();
+private:
+    // need to keep track of threads so we can join them
+    std::vector< std::thread > workers;
+    // the task queue
+    std::queue< std::function<void()> > tasks;
+
+    // synchronization
+    std::mutex queue_mutex;
+    std::condition_variable condition;
+    bool stop;
+};
+
+// the constructor just launches some amount of workers
+inline ThreadPool::ThreadPool(size_t threads)
+    :   stop(false)
+{
+    for(size_t i = 0;i<threads;++i)
+        workers.emplace_back(
+            [this]
+            {
+                for(;;)
+                {
+                    std::function<void()> task;
+
+                    {
+                        std::unique_lock<std::mutex> lock(this->queue_mutex);
+                        this->condition.wait(lock,
+                            [this]{ return this->stop || !this->tasks.empty(); });
+                        if(this->stop && this->tasks.empty())
+                            return;
+                        task = std::move(this->tasks.front());
+                        this->tasks.pop();
+                    }
+
+                    task();
+                }
+            }
+        );
+}
+
+// add new work item to the pool
+template<class F, class... Args>
+auto ThreadPool::enqueue(F&& f, Args&&... args)
+    -> std::future<typename std::invoke_result<F, Args...>::type>
+{
+    using return_type = typename std::invoke_result<F, Args...>::type;
+
+    auto task = std::make_shared< std::packaged_task<return_type()> >(
+            std::bind(std::forward<F>(f), std::forward<Args>(args)...)
+        );
+
+    std::future<return_type> res = task->get_future();
+    {
+        std::unique_lock<std::mutex> lock(queue_mutex);
+
+        // don't allow enqueueing after stopping the pool
+        assert(!stop);
+
+        tasks.emplace([task](){ (*task)(); });
+    }
+    condition.notify_one();
+    return res;
+}
+
+// the destructor joins all threads
+inline ThreadPool::~ThreadPool()
+{
+    {
+        std::unique_lock<std::mutex> lock(queue_mutex);
+        stop = true;
+    }
+    condition.notify_all();
+    for(std::thread &worker: workers)
+        worker.join();
+}


### PR DESCRIPTION
Rendering the image files to bitmaps is a rather heavy task
that consumes a lot of CPU time (relatively).

Instead of rendering the images one by one,
do this in parallel with threads using the available CPU cores.

The threads are managed by ThreadPool that is introduced in this commit
as the base.