### PR TITLE
Avoid doing LoadImage twice for at least PNG files

### DIFF
--- a/src/mywxtools.h
+++ b/src/mywxtools.h
@@ -165,6 +165,12 @@ static vector<uint8_t> ConvertWxImageToBuffer(const wxImage &im, wxBitmapType bm
 static wxImage ConvertBufferToWxImage(vector<uint8_t> &buf, wxBitmapType bmt) {
     wxMemoryInputStream mis(buf.data(), buf.size());
     wxImage im(mis, bmt);
+    if(!im.IsOk()) {
+        int sz = 32;
+        im.Create(sz, sz, false);
+        im.SetRGB(wxRect(0, 0, sz, sz), 0xFF, 0, 0); 
+        // Set to red to indicate error.
+    }
     return im;
 }
 


### PR DESCRIPTION
The parser logic for the error case is now used for the normal parsing of the PNG file. This avoids to have LoadImage being called twice as it is later called when the buffer is converted to wxImage.

If LoadImage fails there, the replacement bitmap is now generated at the generic conversion step.

For JFIF, the parser logic is a little bit more complicated, so let LoadImage be called in this case.