### PR TITLE
Prefix image data with its length and increment TS_VERSION to 22

### DIFF
--- a/TS/docs/file_format_spec.txt
+++ b/TS/docs/file_format_spec.txt
@@ -22,9 +22,9 @@ struct Image
 {
     char ident;   // marks start of image
     // Character value depends on image type, i.e. 'I' for PNG and 'J' for JPEG
+    double display_scale; // display scale of image
+    int64_t imagelen; // length of image (8 bytes)
     char image_data[len]; // whatever format wxImage::LoadFile uses
-    // to know len, you need to parse the png chunks
-    // sadly this means there's no way to read the Cells without doing so
 }
 
 struct Cell

--- a/src/document.h
+++ b/src/document.h
@@ -205,7 +205,9 @@ struct Document {
                 if (image.trefc) {
                     fos.PutC(image.image_type);
                     sos.WriteDouble(image.display_scale);
-                    fos.Write(image.image_data.data(), image.image_data.size());
+                    wxInt64 imagelen(image.image_data.size());
+                    sos.Write64(imagelen);
+                    fos.Write(image.image_data.data(), imagelen);
                     image.savedindex = realindex++;
                 }
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,7 +34,7 @@ static const std::array<uint, 42> celltextcolors = {
 };
 enum { CUSTOMCOLORIDX = 0 };
 
-enum { TS_VERSION = 21, TS_TEXT = 0, TS_GRID, TS_BOTH, TS_NEITHER };
+enum { TS_VERSION = 22, TS_TEXT = 0, TS_GRID, TS_BOTH, TS_NEITHER };
 
 static const uint TS_SELECTION_MASK = 0x80;
 


### PR DESCRIPTION
- This increments the TreeSheets file format version to 22.
- This adds a wxInt64/int64_t before the actual image data indicating its length.
- This updates the corresponding loading and saving procedures.
- This updates the file format specification.