### PR TITLE
Re-layout when create Bitmap of Document

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -715,6 +715,7 @@ struct Document {
         wxBitmap bm(maxx, maxy, 24);
         wxMemoryDC mdc(bm);
         DrawRectangle(mdc, Background(), 0, 0, maxx, maxy);
+        Layout(mdc);
         Render(mdc);
         return bm;
     }


### PR DESCRIPTION
This is necessary otherwise the bitmap will not generated on Windows if e.g. DPI has changed