### PR TITLE
Allow non-privileged installation on Windows

### DIFF
--- a/TS_installer.nsi
+++ b/TS_installer.nsi
@@ -12,11 +12,11 @@ Name "TreeSheets"
 
 OutFile "windows_treesheets_setup.exe"
 
-XPStyle on
+RequestExecutionLevel user
 
-InstallDir $PROGRAMFILES64\TreeSheets
+InstallDir "$LOCALAPPDATA\Programs\TreeSheets"
 
-InstallDirRegKey HKLM "Software\TreeSheets" "Install_Dir"
+InstallDirRegKey HKCU "Software\TreeSheets" "Install_Dir"
 
 SetCompressor /SOLID lzma
 XPStyle on
@@ -69,12 +69,12 @@ Section "TreeSheets (required)"
 
   File /r "TS\*.*"
 
-  WriteRegStr HKLM SOFTWARE\TreeSheets "Install_Dir" "$INSTDIR"
+  WriteRegStr HKCU SOFTWARE\TreeSheets "Install_Dir" "$INSTDIR"
 
-  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\TreeSheets" "DisplayName" "TreeSheets"
-  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\TreeSheets" "UninstallString" '"$INSTDIR\uninstall.exe"'
-  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\TreeSheets" "NoModify" 1
-  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\TreeSheets" "NoRepair" 1
+  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\TreeSheets" "DisplayName" "TreeSheets"
+  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\TreeSheets" "UninstallString" '"$INSTDIR\uninstall.exe"'
+  WriteRegDWORD HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\TreeSheets" "NoModify" 1
+  WriteRegDWORD HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\TreeSheets" "NoRepair" 1
   WriteUninstaller "uninstall.exe"
 
 SectionEnd
@@ -103,8 +103,8 @@ SectionEnd
 
 Section "Uninstall"
 
-  DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\TreeSheets"
-  DeleteRegKey HKLM SOFTWARE\TreeSheets
+  DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\TreeSheets"
+  DeleteRegKey HKCU SOFTWARE\TreeSheets
 
   RMDir /r "$SMPROGRAMS\TreeSheets"
   RMDir /r "$INSTDIR"

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -1181,11 +1181,11 @@ struct MyFrame : wxFrame {
 
     void SetFileAssoc(wxString &exename) {
         #ifdef WIN32
-        SetRegKey(L"HKEY_CLASSES_ROOT\\.cts", L"TreeSheets");
-        SetRegKey(L"HKEY_CLASSES_ROOT\\TreeSheets", L"TreeSheets file");
-        SetRegKey(L"HKEY_CLASSES_ROOT\\TreeSheets\\Shell\\Open\\Command",
+        SetRegKey(L"HKEY_CURRENT_USER\\Software\\Classes\\.cts", L"TreeSheets");
+        SetRegKey(L"HKEY_CURRENT_USER\\Software\\Classes\\TreeSheets", L"TreeSheets file");
+        SetRegKey(L"HKEY_CURRENT_USER\\Software\\Classes\\TreeSheets\\Shell\\Open\\Command",
                   wxString(L"\"") + exename + L"\" \"%1\"");
-        SetRegKey(L"HKEY_CLASSES_ROOT\\TreeSheets\\DefaultIcon",
+        SetRegKey(L"HKEY_CURRENT_USER\\Software\\Classes\\TreeSheets\\DefaultIcon",
                   wxString(L"\"") + exename + L"\",0");
         #else
         // TODO: do something similar for mac/kde/gnome?


### PR DESCRIPTION
This is useful for environments where users usually do not have elevated rights, like in business environments. This commit also changed the file association to the interactive user level.