### PR TITLE
Create the lock file in temp dir instead of home

### DIFF
--- a/src/myapp.h
+++ b/src/myapp.h
@@ -114,7 +114,8 @@ struct MyApp : wxApp {
         }
 
         if (single_instance) {
-            instance_checker = new wxSingleInstanceChecker();
+            instance_checker = new wxSingleInstanceChecker(
+                wxTheApp->GetAppName() + '-' + wxGetUserId(), wxStandardPaths::Get().GetTempDir());
             if (instance_checker->IsAnotherRunning()) {
                 wxClient client;
                 client.MakeConnection(


### PR DESCRIPTION
Before, when running treesheets on Linux, it would create the lock file at `~/treesheets-$user`. This is annoying for a few reasons: if you have a file manager or other app watching home dir, it causes redraw and possibly changes your view; unnecessary r/w to disk; and if treesheets crashes it leaves the file in your home dir.

With this PR, the file is created at `/tmp/treesheets-$user`. `/tmp` is mounted as tmpfs (in RAM) on many distros, so it avoids r/w to disk, and is generally out of view.

I only tested on Linux. treesheets with and without `-i` works as expected.

[According to docs](https://docs.wxwidgets.org/trunk/classwx_single_instance_checker.html#aa69725041ea6c0479f65f6b468a42f1e), path is ignored on Windows. Since the filename is the same as the default, there should be no change on Windows.