### PR TITLE
Insert tag in all cells in the selection

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -2254,11 +2254,13 @@ struct Document {
         int i = 0;
         for (auto tagit = tags.begin(); tagit != tags.end(); ++tagit)
             if (i++ == tagno) {
-                Cell *c = selected.GetCell();
-                if (!c) return OneCell();
-                c->AddUndo(this);
-                c->text.Clear(this, selected);
-                c->text.Insert(this, tagit->first, selected);
+                selected.g->cell->AddUndo(this);
+                loopallcellssel(c, false) {
+                    c->text.Clear(this, selected);
+                    c->text.Insert(this, tagit->first, selected);
+                }
+                selected.g->cell->ResetChildren();
+                selected.g->cell->ResetLayout();
                 Refresh();
                 return nullptr;
             }


### PR DESCRIPTION
This is non-recursive (does not fill cells in subgrids) to be consistent with other commands (e.g. adding icon to the cells in the selection).

This is the PR https://github.com/aardappel/treesheets/pull/455 re-opened (but non-recursive).