### PR TITLE
Add clang-tidy option, default OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,12 @@ add_library(lobster-impl STATIC src/lobster_impl.cpp)
 target_link_libraries(lobster-impl PRIVATE lobster)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
+
+OPTION(WITH_CLANG_TIDY "Run clang-tidy linter" OFF)
+if (WITH_CLANG_TIDY)
 set(CMAKE_CXX_CLANG_TIDY clang-tidy -checks=cppcoreguidelines-*,clang-analyzer-*,readability-*,performance-*,portability-*,concurrency-*,modernize-*)
+endif()
+
 add_executable(
     treesheets
     src/main.cpp


### PR DESCRIPTION
Add a debug option for clang linter.
Default OFF as not all systems install this extra tool.