### PR TITLE
Allow handling of key combinations with Control modifier

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -892,7 +892,11 @@ struct Document {
         if (uk == WXK_NONE || (k < ' ' && k) || k == WXK_DELETE) {
             switch (k) {
                 case WXK_BACK:  // no menu shortcut available in wxwidgets
-                    return Action(dc, A_BACKSPACE);
+                    if (!ctrl) { 
+                        return Action(dc, A_BACKSPACE);
+                    } else {  // prevent Ctrl+H from being treated as Backspace
+                        break;
+                    }
                 case WXK_RETURN: return Action(dc, shift ? A_ENTERGRID : A_ENTERCELL);
                 case WXK_ESCAPE:  // docs say it can be used as a menu accelerator, but it does not
                                   // trigger from there?

--- a/src/mycanvas.h
+++ b/src/mycanvas.h
@@ -126,9 +126,7 @@ struct TSCanvas : public wxScrolledWindow {
         // (scrolling) don't work.
         // The 128 makes sure unicode entry on e.g. Polish keyboards still works.
         // (on Linux in particular).
-        // Also prevent the translation from Ctrl+letter into ASCII control characters.
-        if (((ce.GetModifiers() == wxMOD_ALT) || (ce.GetModifiers() == wxMOD_CONTROL)) 
-            && (ce.GetUnicodeKey() < 128)) {
+        if ((ce.GetModifiers() == wxMOD_ALT) && (ce.GetUnicodeKey() < 128)) {
             ce.Skip();
             return;
         }


### PR DESCRIPTION
For the special case of Ctrl+H, prevent it from being treated as backspace by checking whether Ctrl is pressed down.

Excluding all combinations of Ctrl+Letter from handling by `Key` in `doc` is a little bit of an overshoot with unwanted side effects (e.g. Ctrl+arrow combinations not working properly).