### PR TITLE
Remember and load TreeSheets file with zoom level

### DIFF
--- a/TS/docs/file_format_spec.txt
+++ b/TS/docs/file_format_spec.txt
@@ -1,12 +1,13 @@
-File format spec for TreeSheets .cts files, version 21. This should be enough for a programmer to write an importer/exporter.
+File format spec for TreeSheets .cts files, version 23. This should be enough for a programmer to write an importer/exporter.
 
 struct File     // not really a struct, i.e. no alignment, read an element at a time
 {
     char magic[4] = "TSFF";
-    char version = 21;
-    // TreeSheets saves the selection when the file is saved.
+    char version = 23;
+    // TreeSheets saves the selection and the zoom level when the file is saved.
     int xs; // xs is the number of cells within the selection in x direction
     int ys; // ys is the number of cells within the selection in y direction
+    int zoomlevel; // zoom level of the document
     
     Image images[0 or more];
 

--- a/src/document.h
+++ b/src/document.h
@@ -20,6 +20,7 @@ struct Document {
     int originx, originy, maxx, maxy, centerx, centery;
     int layoutxs, layoutys, hierarchysize, fgutter;
     int lasttextsize, laststylebits;
+    int initialzoomlevel;
     Cell *curdrawroot;  // for use during Render() calls
     Vector<UndoItem *> undolist, redolist;
     Vector<Selection> drawpath;
@@ -114,6 +115,7 @@ struct Document {
           dpichanged(false),
           scaledviewingmode(false),
           currentviewscale(1),
+          initialzoomlevel(0),
           searchfilter(false),
           editfilter(0) {
         dataobjc = new wxDataObjectComposite();  // deleted by DropTarget
@@ -192,6 +194,7 @@ struct Document {
             fos.Write(&vers, 1);
             sos.Write8(selected.xs);
             sos.Write8(selected.ys);
+            sos.Write8(!drawpath.size() ? 0 : drawpath.size()); // zoom level
             RefreshImageRefCount(true);
             int realindex = 0;
             loopv(i, sys->imagelist) {
@@ -663,6 +666,7 @@ struct Document {
         if (hover.g) hover.g->DrawHover(this, dc, hover);
         if (scaledviewingmode) { dc.SetUserScale(1, 1); }
         if (scrolltoselection) {
+            Zoom(initialzoomlevel, dc);
             ScrollIfSelectionOutOfView(dc, selected);
             scrolltoselection = false;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ static const std::array<uint, 42> celltextcolors = {
 };
 enum { CUSTOMCOLORIDX = 0 };
 
-enum { TS_VERSION = 22, TS_TEXT = 0, TS_GRID, TS_BOTH, TS_NEITHER };
+enum { TS_VERSION = 23, TS_TEXT = 0, TS_GRID, TS_BOTH, TS_NEITHER };
 
 static const uint TS_SELECTION_MASK = 0x80;
 

--- a/src/system.h
+++ b/src/system.h
@@ -270,7 +270,7 @@ struct System {
             } else {
                 xs = ys = 1;
             }
-
+            int zoomlevel = versionlastloaded >= 23 ? dis.Read8() : 0;
             fakelasteditonload = wxDateTime::Now().GetValue();
 
             loadimageids.setsize(0);
@@ -343,6 +343,7 @@ struct System {
                             doc->modified = true;
                         }
                         doc->InitWith(root, filename, ics, xs, ys);
+                        doc->initialzoomlevel = zoomlevel;
 
                         if (versionlastloaded >= 11) {
                             for (;;) {


### PR DESCRIPTION
Rationale: In a TreeSheets document with many levels (nested grids etc.), it is an improvement for the convenience to already load the document with the zoom level that was set when the document has been saved.