### PR TITLE
Do not zoom to initialzoomlevel when DPI changes

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -665,8 +665,11 @@ struct Document {
         DrawSelect(dc, selected);
         if (hover.g) hover.g->DrawHover(this, dc, hover);
         if (scaledviewingmode) { dc.SetUserScale(1, 1); }
-        if (scrolltoselection) {
+        if (initialzoomlevel) {
             Zoom(initialzoomlevel, dc);
+            initialzoomlevel = 0;
+        }
+        if (scrolltoselection) {
             ScrollIfSelectionOutOfView(dc, selected);
             scrolltoselection = false;
         }


### PR DESCRIPTION
Do not zoom with initial zoom level in other occurences when `scrolltoselection` is invoked, e.g. `OnDPIChanged`
→ Separate `scrolltoselection` signal from newly added `initialzoomtolevel` signal