### PR TITLE
Slightly modernise HTML export

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -852,18 +852,17 @@ struct Document {
                 case A_EXPHTMLB:
                 case A_EXPHTMLO:
                     dos.WriteString(
-                        L"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 3.2 Final//EN\">\n"
+                        L"<!DOCTYPE html>\n"
                         L"<html>\n<head>\n<style>\n"
                         L"body { font-family: sans-serif; }\n"
                         L"table, th, td { border: 1px solid #A0A0A0; border-collapse: collapse;"
-                        L" padding: 3px; vertical-align: top; }\n"
+                        L" padding: 3px; vertical-align: top; font-weight: normal; }\n"
                         L"li { }\n</style>\n"
                         L"<title>export of TreeSheets file ");
                     dos.WriteString(filename);
                     dos.WriteString(
-                        L"</title>\n<meta http-equiv=\"Content-Type\" content=\"text/html; "
-                        L"charset=UTF-8\" "
-                        L"/>\n</head>\n<body>\n");
+                        L"</title>\n<meta charset=\"UTF-8\" />\n"
+                        L"</head>\n<body>\n");
                     dos.WriteString(content);
                     dos.WriteString(L"</body>\n</html>\n");
                     break;

--- a/src/document.h
+++ b/src/document.h
@@ -856,7 +856,7 @@ struct Document {
                         L"<html>\n<head>\n<style>\n"
                         L"body { font-family: sans-serif; }\n"
                         L"table, th, td { border: 1px solid grey; border-collapse: collapse;"
-                        L" padding: 3px; }\n"
+                        L" padding: 3px; vertical-align: top; }\n"
                         L"li { }\n</style>\n"
                         L"<title>export of TreeSheets file ");
                     dos.WriteString(filename);

--- a/src/document.h
+++ b/src/document.h
@@ -855,7 +855,7 @@ struct Document {
                         L"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 3.2 Final//EN\">\n"
                         L"<html>\n<head>\n<style>\n"
                         L"body { font-family: sans-serif; }\n"
-                        L"table, th, td { border: 1px solid grey; border-collapse: collapse;"
+                        L"table, th, td { border: 1px solid #A0A0A0; border-collapse: collapse;"
                         L" padding: 3px; vertical-align: top; }\n"
                         L"li { }\n</style>\n"
                         L"<title>export of TreeSheets file ");

--- a/src/grid.h
+++ b/src/grid.h
@@ -614,7 +614,7 @@ struct Grid {
                   wxString::Format(L"<ul style=\"font-size: %dpt;\">\n",
                       font_size).wc_str());
         foreachcellinsel(c, s) {
-            if (x == 0) Formatter(r, format, indent, L"<row>\n", L"<tr valign=top>\n", L"");
+            if (x == 0) Formatter(r, format, indent, L"<row>\n", L"<tr>\n", L"");
             r.Append(c->ToText(indent, s, format, doc));
             if (format == A_EXPCSV) r.Append(x == xs - 1 ? '\n' : ',');
             if (x == xs - 1) Formatter(r, format, indent, L"</row>\n", L"</tr>\n", L"");


### PR DESCRIPTION
The current doctype triggers [quirks mode](https://developer.mozilla.org/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode), which is for _pre_-IE6 compatibility.

I tested all 3 HTML export (table, bullet, outline) of tutorial.cts to make sure they look the same in standards mode (in Firefox 115 on Linux).

The table style looks 100% the same, pixel-perfect. The outline style has negligible alignment differences (some text looks higher by 1px).

The bullet style has 1 visible difference: in quirks mode, nested lists (`li > ul`) with no text in the parent li has extra padding on top, which I would say is a bug/unintended (from TS' point of view), since there is no extra padding anywhere else.

![Screenshot comparing nested lists in quirks mode and standards mode](https://github.com/aardappel/treesheets/assets/23169302/8e0e4ebc-9e6c-41a9-a460-c813f281c2d9)

The `font-weight: normal` is added to reset the font weight in nested tables, because standards mode properly inherits font styles in tables which quirks mode did not.

Benefit of this change is users who edit the HTML export (e.g. to apply additional styling) should have more predictable modern behaviour.