### PR TITLE
Undo red search highlight removal

### DIFF
--- a/src/text.h
+++ b/src/text.h
@@ -208,9 +208,12 @@ struct Text {
         leftoffset = h;
         int i = 0;
         int lines = 0;
+        bool searchfound = IsInSearch();
         bool istag = cell->IsTag(doc);
         if (cell->tiny) {
-            if (filtered)
+            if (searchfound)
+                dc.SetPen(*wxRED_PEN);
+            else if (filtered)
                 dc.SetPen(*wxLIGHT_GREY_PEN);
             else if (istag)
                 dc.SetPen(*wxBLUE_PEN);
@@ -240,7 +243,9 @@ struct Text {
                     }
                 }
             } else {
-                if (filtered)
+                if (searchfound)
+                    dc.SetTextForeground(*wxRED);
+                else if (filtered)
                     dc.SetTextForeground(*wxLIGHT_GREY);
                 else if (istag)
                     dc.SetTextForeground(*wxBLUE);
@@ -249,7 +254,7 @@ struct Text {
                 int tx = bx + 2 + ixs;
                 int ty = by + lines * h;
                 dc.DrawText(curl, tx + g_margin_extra, ty + g_margin_extra);
-                if (filtered || istag || cell->textcolor)
+                if (searchfound || filtered || istag || cell->textcolor)
                     dc.SetTextForeground(*wxBLACK);
             }
             lines++;


### PR DESCRIPTION
In https://github.com/aardappel/treesheets/pull/346 the red highlighting of matching text when searching has been removed, which makes seeing results when using a "dark mode" (white text on dark background) impossible.

Re-add this feature for better accessibility.