### PR TITLE
Do not close files if there are any unconfirmed changes

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -751,10 +751,14 @@ struct Document {
         return false;
     }
 
+    void RemoveTmpFile() {
+        if (!filename.empty() && ::wxFileExists(sys->TmpName(filename)))
+            ::wxRemoveFile(sys->TmpName(filename));
+    }
+
     bool CloseDocument() {
         bool keep = CheckForChanges();
-        if (!keep && !filename.empty() && ::wxFileExists(sys->TmpName(filename)))
-            ::wxRemoveFile(sys->TmpName(filename));
+        if (!keep) RemoveTmpFile();
         return keep;
     }
 


### PR DESCRIPTION
Fix issue where if there are any files with unsaved changes in the middle of the file list, the files in front of them will get closed, and then saving/canceling closing the files with changes causes the closed files to be lost from the remembered open files.
Now all unsaved files must be saved/discarded before closing may happen, which keeps remembered file list intact.