### PR TITLE
gitignore script folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ TreeSheets/x64
 *.ipdb
 *.iobj
 TreeSheets/gettext_bin
+TS/scripts


### PR DESCRIPTION
Add TS/scripts to gitignore since if there are any user scripts in there they will appear on git status as untracked.
Any new example scripts can be added directly, and a nested git repository can be setup within the scripts folder to have source control over user scripts.