### PR TITLE
Align selection to center

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -280,10 +280,10 @@ struct Document {
                     sw->SetScrollbars(1, 1, layoutxs, layoutys,
                                       r.width > canvasw || r.x < originx
                                           ? r.x
-                                          : r.x + r.width > maxx ? r.x + r.width - canvasw : curx,
+                                          : r.x + r.width > maxx ? r.x + r.width / 2 - canvasw / 2 : curx,
                                       r.height > canvash || r.y < originy
                                           ? r.y
-                                          : r.y + r.height > maxy ? r.y + r.height - canvash : cury,
+                                          : r.y + r.height > maxy ? r.y + r.height / 2 - canvash / 2 : cury,
                                       true);
                     RefreshReset();
                     return true;


### PR DESCRIPTION
This aligns the selection to center when selection was out of view before.

Trade-off:
🇨🇭 better placement of cells when zooming in and out
➖ bigger "jumps" when scrolling to the next cell that is outside of the view(port) as the selection will be placed to center