### PR TITLE
Copy solely the text string when TextEdit is active (DnD).

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -410,6 +410,19 @@ struct Document {
         Refresh();
     }
 
+    auto CopyEntireCells(wxString &s) {
+        sys->clipboardcopy = s;
+        wxString html = selected.g->ConvertToText(selected, 0, A_EXPHTMLT, this);
+        auto htmlobj = 
+        #ifdef __WXGTK__
+            new wxCustomDataObject(wxDF_HTML);
+            htmlobj->SetData(html.Len(), html);
+        #else
+            new wxHTMLDataObject(html);
+        #endif
+        return htmlobj;
+    }
+
     void Copy(int mode) {
         Cell *c = selected.GetCell();
         sys->clipboardcopy = wxEmptyString;
@@ -425,20 +438,12 @@ struct Document {
                         dragdata.Add(new wxBitmapDataObject(bm));
                     }
                 } else {
-                    wxString s, html;
-                    s = selected.g->ConvertToText(selected, 0, A_EXPTEXT, this);
-                    html = selected.g->ConvertToText(selected, 0, A_EXPHTMLT, this);
-                    if (!selected.TextEdit()) sys->clipboardcopy = s;
-                    
+                    wxString s = selected.g->ConvertToText(selected, 0, A_EXPTEXT, this);
                     dragdata.Add(new wxTextDataObject(s));
-                    auto *htmlobj = 
-                    #ifdef __WXGTK__
-                        new wxCustomDataObject(wxDF_HTML);
-                    htmlobj->SetData(html.Len(), html);
-                    #else
-                        new wxHTMLDataObject(html);
-                    #endif
-                    dragdata.Add(htmlobj);
+                    if (!selected.TextEdit()) {
+                        auto htmlobj = CopyEntireCells(s);
+                        dragdata.Add(htmlobj);
+                    }
                 }
                 wxDropSource dragsource(dragdata, sw);
                 dragsource.DoDragDrop(true);
@@ -474,15 +479,7 @@ struct Document {
                     wxString s = selected.g->ConvertToText(selected, 0, A_EXPTEXT, this);
                     clipboarddata->Add(new wxTextDataObject(s));
                     if (!selected.TextEdit()) {
-                        sys->clipboardcopy = s;
-                        wxString html = selected.g->ConvertToText(selected, 0, A_EXPHTMLT, this);
-                        auto *htmlobj = 
-                        #ifdef __WXGTK__
-                            new wxCustomDataObject(wxDF_HTML);
-                        htmlobj->SetData(html.Len(), html);
-                        #else
-                            new wxHTMLDataObject(html);
-                        #endif
+                        auto htmlobj = CopyEntireCells(s);
                         clipboarddata->Add(htmlobj);
                     }
                     if (wxTheClipboard->Open()) {


### PR DESCRIPTION
Same as 7f68776a9e072520c735479929efecd0d58f362d but for Drag and Drop operation.