### PR TITLE
Accelerator keys for zoom are not always fetched at menu level

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -972,6 +972,14 @@ struct Document {
                     }
                     return Action(
                         dc, shift ? (ctrl ? A_PREVFILE : A_PREV) : (ctrl ? A_NEXTFILE : A_NEXT));
+                case WXK_PAGEUP:
+                    if (ctrl) return Action(dc, A_ZOOMIN);
+                    sw->CursorScroll(0, -g_scrollratecursor); 
+                    return nullptr;
+                case WXK_PAGEDOWN:
+                    if (ctrl) return Action(dc, A_ZOOMOUT);
+                    sw->CursorScroll(0, g_scrollratecursor); 
+                    return nullptr;
                 #endif
             }
         } else if (uk >= ' ') {


### PR DESCRIPTION
When the key events for zooming are first fetched at canvas level, it will not be propagated to the menu level.

This applies to wxGTK.