### PR TITLE
Consider scrollbars overlapping the scrolled window at its edges

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -273,17 +273,17 @@ struct Document {
             sw->GetClientSize(&canvasw, &canvash);
             if ((layoutys > canvash || layoutxs > canvasw) && s.g) {
                 wxRect r = s.g->GetRect(this, s, true);
-                if (r.y < originy || r.y + r.height > maxy || r.x < originx ||
-                    r.x + r.width > maxx) {
+                if (r.y < originy || r.y + r.height > maxy - wxSYS_HSCROLL_Y || r.x < originx ||
+                    r.x + r.width > maxx - wxSYS_VSCROLL_X) {
                     int curx, cury;
                     sw->GetViewStart(&curx, &cury);
                     sw->SetScrollbars(1, 1, layoutxs, layoutys,
-                                      r.width > canvasw || r.x < originx
+                                      r.width > canvasw - wxSYS_VSCROLL_X || r.x < originx
                                           ? r.x
-                                          : r.x + r.width > maxx ? r.x + r.width - canvasw : curx,
-                                      r.height > canvash || r.y < originy
+                                          : r.x + r.width > maxx - wxSYS_VSCROLL_X ? r.x + r.width - canvasw + wxSYS_VSCROLL_X: curx,
+                                      r.height > canvash - wxSYS_HSCROLL_Y || r.y < originy
                                           ? r.y
-                                          : r.y + r.height > maxy ? r.y + r.height - canvash : cury,
+                                          : r.y + r.height > maxy - wxSYS_HSCROLL_Y ? r.y + r.height - canvash + wxSYS_HSCROLL_Y : cury,
                                       true);
                     RefreshReset();
                     return true;


### PR DESCRIPTION
This assumes that the horizontal scrollbar is at the bottom edge and
that the vertical scrollbar is at the right edge of the scrolled window.

This commit should avoid the situation where the selection to scroll to
is hidden behind the scrollbar.