### PR TITLE
Standard instruction works

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,7 @@ if(NOT APPLE AND NOT WIN32)
     include(GNUInstallDirs)
 endif()
 
-# set(CMAKE_CXX_STANDARD 17)  # this doesn't work correctly on all CMake versions :(
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+set(CMAKE_CXX_STANDARD 17)
 
 OPTION(TREESHEETS_WITH_STATIC_WXWIDGETS "Build wxWidgets along with TreeSheets and link TreeSheets against static wxWidgets library" OFF)
 


### PR DESCRIPTION
The workaround dated back from 2018. I think it is obsolete by now.