### PR TITLE
Tune the input for the hash

### DIFF
--- a/src/system.h
+++ b/src/system.h
@@ -577,7 +577,9 @@ struct System {
     }
 
     int AddImageToList(double sc, vector<uint8_t> &&idv, char iti) {
-        auto hash = FNV1A64(idv);
+        int max = 4096;
+        auto subvector = vector<uint8_t>(idv.begin(), idv.begin() + min(idv.size(), max));
+        auto hash = FNV1A64(subvector);
         loopv(i, imagelist) {
             if (imagelist[i]->hash == hash) return i;
         }


### PR DESCRIPTION
Profiling TreeSheets shows that hashing the entire image data takes up a lot of time.

This commit tweaks this by just hashing a specific chunk of the image data at its beginning.