### PR TITLE
Do not handle Alt/Ctrl shortcuts with printable characters

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -968,7 +968,7 @@ struct Document {
                     return nullptr;
                 #endif
             }
-        } else if (uk >= ' ') {
+        } else if (uk >= ' ' && !alt && !ctrl) {
             if (!selected.g) return NoSel();
             Cell *c = selected.ThinExpand(this);
             if (!c) return OneCell();


### PR DESCRIPTION
They should be left `unprocessed` in Document::Key, so that they will be correctly handled by the menu bar.