### PR TITLE
Properly process returned `const wxChar *`

### DIFF
--- a/src/system.h
+++ b/src/system.h
@@ -158,7 +158,7 @@ struct System {
         newdoc->sw->SetFocus();
         newdoc->UpdateFileName();
         wxClientDC dc(newdoc->sw);
-        newdoc->SearchNext(dc, false, false, false);
+        newdoc->sw->Status(newdoc->SearchNext(dc, false, false, false));
     }
 
     void Init(const wxString &filename) {


### PR DESCRIPTION
`void System::TabChange(Document*)` calls
`const wxChar* Document::SearchNext(wxDC&, bool, bool, bool)`.

The returned result of `Document::SearchNext` should be properly processed on the stack. This commit fixes this by processing the returned `const wxChar*` with the `void TSCanvas::Status(const wxChar*)` function.