### PR TITLE
Reset layout when a single line of text is dropped

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -2116,6 +2116,7 @@ struct Document {
                         if (as.size()) {
                             if (as.size() <= 1) {
                                 c->AddUndo(this);
+                                c->ResetLayout();
                                 PasteSingleText(c, as[0]);
                             } else {
                                 c->parent->AddUndo(this);


### PR DESCRIPTION
When a single line of text is dropped onto a cell, the layout is not reset.

This is not optimal when the text length is longer than e.g. the column width because the text gets cut as the layout is not adapted.

This commit fixes this by resetting the layout in the case of a drop of a single line of text.