### PR TITLE
Constify and pass `filename` by reference in `Document::InitWith(...)`

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -137,7 +137,7 @@ struct Document {
 
     uint Background() { return rootgrid ? rootgrid->cellcolor : 0xFFFFFF; }
 
-    void InitWith(Cell *r, wxString filename, Cell *ics, int xs, int ys) {
+    void InitWith(Cell *r, const wxString &filename, Cell *ics, int xs, int ys) {
         rootgrid = r;
         if (ics) {
             Grid* ipg = ics->parent->grid;


### PR DESCRIPTION
The wxString is just passed further to
`Document::ChangeFileName(const wxString&, bool)`, so just pass it by reference and constify the argument.