### PR TITLE
Constify read-only Selection argument for FindLink and FindExact

### DIFF
--- a/src/cell.h
+++ b/src/cell.h
@@ -438,7 +438,7 @@ struct Cell {
         return best;
     }
 
-    Cell *FindLink(Selection &s, Cell *link, Cell *best, bool &lastthis, bool &stylematch,
+    Cell *FindLink(const Selection &s, Cell *link, Cell *best, bool &lastthis, bool &stylematch,
                    bool forward, bool image) {
         if (grid) best = grid->FindLink(s, link, best, lastthis, stylematch, forward, image);
         if (link == this) {
@@ -466,7 +466,7 @@ struct Cell {
         text.ReplaceStr(str, lstr);
     }
 
-    Cell *FindExact(wxString &s) {
+    Cell *FindExact(const wxString &s) {
         return text.t == s ? this : (grid ? grid->FindExact(s) : nullptr);
     }
 

--- a/src/grid.h
+++ b/src/grid.h
@@ -302,7 +302,7 @@ struct Grid {
         }
     }
 
-    Cell *FindLink(Selection &s, Cell *link, Cell *best, bool &lastthis, bool &stylematch,
+    Cell *FindLink(const Selection &s, Cell *link, Cell *best, bool &lastthis, bool &stylematch,
                    bool forward, bool image) {
         if (forward) {
             foreachcell(c) best = c->FindLink(s, link, best, lastthis, stylematch, forward, image);
@@ -903,7 +903,7 @@ struct Grid {
               (int(__cdecl *)(const void *, const void *))sortfunc);
     }
 
-    Cell *FindExact(wxString &s) {
+    Cell *FindExact(const wxString &s) {
         foreachcell(c) {
             Cell *f = c->FindExact(s);
             if (f) return f;


### PR DESCRIPTION
This commit constifies the Selection argument passed by reference for
`{Cell,Grid}::{FindLink,FindExact}(...)` as they are only read.