### PR TITLE
Simplify, improve and enhance replace logic

### DIFF
--- a/src/myframe.h
+++ b/src/myframe.h
@@ -920,11 +920,7 @@ struct MyFrame : wxFrame {
                     } else if (tc == replaces) {
                         // OnReplaceEnter equivalent implementation for MSW
                         // as EVT_TEXT_ENTER event is not generated.
-                        if (sys->frame->replaces->GetValue().Len() == 0) {
-                            sw->SetFocus();
-                        } else {
-                            sw->doc->Action(dc, A_REPLACEONCEJ);
-                        }
+                        sw->doc->Action(dc, A_REPLACEONCEJ);
                     }
                     return;
                 }
@@ -1077,7 +1073,7 @@ struct MyFrame : wxFrame {
 
     void OnSearchReplaceEnter(wxCommandEvent &ce) {
         TSCanvas *sw = GetCurTab();
-        if (ce.GetString().Len() == 0) {
+        if (ce.GetId() == A_SEARCH && ce.GetString().Len() == 0) {
             sw->SetFocus();
         } else {
             wxClientDC dc(sw);

--- a/src/text.h
+++ b/src/text.h
@@ -423,32 +423,25 @@ struct Text {
     }
 
     void ReplaceStr(const wxString &str, const wxString &lstr) {
-        wxString lowert;
-        wxString *fort;
-        const wxString *istr;
-        
-        if (lstr.IsEmpty()) {
-            fort = &t;
-            istr = &str;
-        } else {
-            lowert = t.Lower();
-            fort = &lowert;
-            istr = &lstr;
-        }
-
-        for (int i = 0, j; (j = fort->Mid(i).Find(sys->searchstring)) >= 0;) 
-        {
-            // does this need WasEdited()?
-            i += j;
-            fort->Remove(i, sys->searchstring.Len());
-            fort->insert(i, *istr);
-
-            if (!sys->casesensitivesearch) {
+        if (sys->casesensitivesearch) {
+            for (int i = 0, j; (j = t.Mid(i).Find(sys->searchstring)) >= 0;) {
+                // does this need WasEdited()?
+                i += j;
                 t.Remove(i, sys->searchstring.Len());
                 t.insert(i, str);
+                i += str.Len();
             }
-
-            i += str.Len();
+        } else {
+            wxString lowert = t.Lower();
+            for (int i = 0, j; (j = lowert.Mid(i).Find(sys->searchstring)) >= 0;) {
+                // does this need WasEdited()?
+                i += j;
+                lowert.Remove(i, sys->searchstring.Len());
+                t.Remove(i, sys->searchstring.Len());
+                lowert.insert(i, lstr);
+                t.insert(i, str);
+                i += str.Len();
+            }
         }
     }
 


### PR DESCRIPTION
This commit allows to replace a search text with an empty replace string, so to delete the match text.

It also removes a bug where the matched string was replaced twice in the case-insensitive mode.