### PR TITLE
`wxSizeEvent` should not trigger a repaint of the document

### DIFF
--- a/src/mycanvas.h
+++ b/src/mycanvas.h
@@ -160,7 +160,7 @@ struct TSCanvas : public wxScrolledWindow {
         }
     }
 
-    void OnSize(wxSizeEvent &se) { doc->Refresh(); }
+    void OnSize(wxSizeEvent &se) {}
     void OnContextMenuClick(wxContextMenuEvent &cme) {
         if (lastrmbwaswithctrl) {
             wxMenu *tagmenu = new wxMenu();


### PR DESCRIPTION
The document is rendered into a scrolled window. If the size of the scrolled window for the canvas is changed, the rendered document can stay the same as it can be navigated by the scrollbars.

This should avoid the expensive `Document::Refresh()` call.