### PR TITLE
Avoid extraneous call for `DrawSelect` in case of a zoom

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -667,17 +667,18 @@ struct Document {
         sw->DoPrepareDC(dc);
         ShiftToCenter(dc);
         Render(dc);
-        DrawSelect(dc, selected);
-        if (hover.g) hover.g->DrawHover(this, dc, hover);
-        if (scaledviewingmode) { dc.SetUserScale(1, 1); }
         if (initialzoomlevel) {
             Zoom(initialzoomlevel, dc);
             initialzoomlevel = 0;
+        } else {
+            DrawSelect(dc, selected);
         }
         if (scrolltoselection) {
             ScrollIfSelectionOutOfView(dc, selected);
             scrolltoselection = false;
         }
+        if (hover.g) hover.g->DrawHover(this, dc, hover);
+        if (scaledviewingmode) { dc.SetUserScale(1, 1); }
     }
 
     void Print(wxDC &dc, wxPrintout &po) {


### PR DESCRIPTION
`Document::Zoom(int, wxDC&, bool, bool)` calls
`Document::DrawSelectMove(wxDC&, Selection&, bool, bool)` which calls `Document::DrawSelect(wxDC&, Selection&, bool, bool)`. So in this case, we do not need to call
`Document::DrawSelect(wxDC&, Selection&, bool, bool)` again.