### PR TITLE
Do not install wxWidgets along with TreeSheets static build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,6 @@ jobs:
       run: cmake --build _build -j4
     - name: install files
       run: cmake --install _build
-    - name: remove unnecessary files
-      run: rm -rf TreeSheets-relocatable/include TreeSheets-relocatable/lib TreeSheets-relocatable/bin/wx*
     - name: zip
       run: zip -r linux_treesheets_${{ matrix.cxx }}.zip TreeSheets-relocatable
     - name: upload build artifacts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ OPTION(TREESHEETS_WITH_STATIC_WXWIDGETS "Build wxWidgets along with TreeSheets a
 
 if (TREESHEETS_WITH_STATIC_WXWIDGETS)
     set(wxBUILD_SHARED OFF)
+    set(wxBUILD_INSTALL OFF CACHE BOOL "Avoid install/uninstall target for wxWidgets in static build" FORCE)
     add_subdirectory(lib/wxWidgets)
 else()
     find_package(wxWidgets REQUIRED aui adv core xml net)


### PR DESCRIPTION
This avoids that a install and uninstall target for wxWidgets itself is created. With this considered, only the TreeSheets files are installed, but none from wxWidgets. 