### PR TITLE
Replace wxScrolledWindow with wxScrolledCanvas

### DIFF
--- a/src/mycanvas.h
+++ b/src/mycanvas.h
@@ -1,4 +1,4 @@
-struct TSCanvas : public wxScrolledWindow {
+struct TSCanvas : public wxScrolledCanvas {
     MyFrame *frame;
     Document *doc;
 
@@ -8,7 +8,7 @@ struct TSCanvas : public wxScrolledWindow {
     wxPoint lastmousepos;
 
     TSCanvas(MyFrame *fr, wxWindow *parent, const wxSize &size = wxDefaultSize)
-        : wxScrolledWindow(parent, wxID_ANY, wxDefaultPosition, size,
+        : wxScrolledCanvas(parent, wxID_ANY, wxDefaultPosition, size,
                            wxScrolledWindowStyle | wxWANTS_CHARS),
           frame(fr),
           doc(nullptr),


### PR DESCRIPTION
According to <https://docs.wxwidgets.org/3.2.5/classwx_scrolled.html>, `wxScrolledCanvas` is more suited to the use case of TreeSheets as there are no child controls in `TSCanvas`.