### PR TITLE
Put clipboard data on the system stack

### DIFF
--- a/src/myframe.h
+++ b/src/myframe.h
@@ -789,7 +789,7 @@ struct MyFrame : wxFrame {
             nb->AddPage(sw, _(L"<unnamed>"), true, wxNullBitmap);
         else
             nb->InsertPage(0, sw, _(L"<unnamed>"), true, wxNullBitmap);
-        sw->SetDropTarget(new DropTarget(doc->dataobjc));
+        sw->SetDropTarget(new DropTarget(&sys->dataobjc));
         sw->SetFocus();
         return sw;
     }

--- a/src/system.h
+++ b/src/system.h
@@ -81,6 +81,12 @@ struct System {
     uint lastcellcolor = 0xFFFFFF;
     uint lasttextcolor = 0;
     uint lastbordcolor = 0xA0A0A0;
+    wxDataObjectComposite dataobjc;
+    wxTextDataObject dataobjt;
+    wxBitmapDataObject dataobji;
+    wxFileDataObject dataobjf;
+    //wxHTMLDataObject dataobjh;
+    //wxRichTextBufferDataObject dataobjr;
 
     System(bool portable)
         : defaultfont(
@@ -141,6 +147,12 @@ struct System {
 
         // fsw.Connect(wxID_ANY, wxID_ANY, wxEVT_FSWATCHER,
         // wxFileSystemWatcherEventHandler(System::OnFileChanged));
+
+        dataobjc.Add(&dataobji);
+        dataobjc.Add(&dataobjt);
+        dataobjc.Add(&dataobjf);
+        //dataobjc.Add(dataobjh, true);  // Prefer HTML over text, doesn't seem to work.
+        //dataobjc.Add(dataobjr);
     }
 
     ~System() {


### PR DESCRIPTION
The clipboard data structures are created by the first document on the heap and then are subsequently overridden by other documents.

It can be a better design to put the clipboard data into one central place on the stack of `System` as it is available during the lifetime of the program.