### PR TITLE
Avoid wxDataObjectComposite for pasting

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -2103,12 +2103,13 @@ struct Document {
         Cell *c = selected.ThinExpand(this);
         if (!c) return;
         wxBusyCursor wait;
+        bool wantsrefresh = false;
 
         if (pdataobjt.GetText() != wxEmptyString) {
             wxString s = pdataobjt.GetText();
             if ((sys->clipboardcopy == s) && sys->cellclipboard) {
                 c->Paste(this, sys->cellclipboard.get(), selected);
-                Refresh();
+                wantsrefresh = true;
             } else {
                 const wxArrayString &as = wxStringTokenize(s, LINE_SEPERATOR);
                 if (as.size()) {
@@ -2124,7 +2125,7 @@ struct Document {
                         if (!c->HasText())
                             c->grid->MergeWithParent(c->parent->grid, selected, this);
                     }
-                    Refresh();
+                    wantsrefresh = true;
                 }
             }
         }
@@ -2135,7 +2136,7 @@ struct Document {
                 if (as.size() > 1) sw->Status(_(L"Cannot drag & drop more than 1 file."));
                 c->AddUndo(this);
                 if (!LoadImageIntoCell(as[0], c, sys->frame->csf)) PasteSingleText(c, as[0]);
-                Refresh();
+                wantsrefresh = true;
             }
         }
 
@@ -2145,8 +2146,10 @@ struct Document {
             vector<uint8_t> idv = ConvertWxImageToBuffer(im, wxBITMAP_TYPE_PNG);
             SetImageBM(c, std::move(idv), sys->frame->csf);
             c->Reset();
-            Refresh();
+            wantsrefresh = true;
         }
+
+        if (wantsrefresh) Refresh();
     }
 
     const wxChar *Sort(bool descending) {

--- a/src/document.h
+++ b/src/document.h
@@ -1570,6 +1570,15 @@ struct Document {
             case A_PASTE:
                 if (!(c = selected.ThinExpand(this))) return OneCell();
                 if (wxTheClipboard->Open()) {
+                    // wxDataObjectComposite does not work properly under Wayland for text atoms
+                    // and also needs to be allocated to the heap because of the behavior of its destructor.
+                    //
+                    // Instead of aggregating the possible targets to one wxDataObjectComposite on the heap, 
+                    // just create one wxDataObjectSimple subclass instance for each type TreeSheets can handle 
+                    // on the stack and try to paste the clipboard content into it.
+                    //
+                    // For drag and drop operations, wxDataObjectComposite is still mandatory, so keep one 
+                    // instance for it separately at the System instance.
                     wxTextDataObject pdataobjt;
                     wxBitmapDataObject pdataobji;
                     wxFileDataObject pdataobjf;

--- a/src/document.h
+++ b/src/document.h
@@ -1570,8 +1570,13 @@ struct Document {
             case A_PASTE:
                 if (!(c = selected.ThinExpand(this))) return OneCell();
                 if (wxTheClipboard->Open()) {
-                    wxTheClipboard->GetData(*sys->dataobjc);
-                    PasteOrDrop();
+                    wxTextDataObject pdataobjt;
+                    wxBitmapDataObject pdataobji;
+                    wxFileDataObject pdataobjf;
+                    wxTheClipboard->GetData(pdataobjt);
+                    wxTheClipboard->GetData(pdataobji);
+                    wxTheClipboard->GetData(pdataobjf);
+                    PasteOrDrop(pdataobjt, pdataobji, pdataobjf);
                     wxTheClipboard->Close();
                 } else if (sys->cellclipboard) {
                     c->Paste(this, sys->cellclipboard.get(), selected);
@@ -2083,75 +2088,55 @@ struct Document {
 
     void PasteSingleText(Cell *c, const wxString &t) { c->text.Insert(this, t, selected); }
 
-    void PasteOrDrop() {
+    void PasteOrDrop(const wxTextDataObject &pdataobjt,
+                     const wxBitmapDataObject &pdataobji,
+                     const wxFileDataObject &pdataobjf) {
         Cell *c = selected.ThinExpand(this);
         if (!c) return;
         wxBusyCursor wait;
-        switch (sys->dataobjc->GetReceivedFormat().GetType()) {
-            case wxDF_FILENAME: {
-                const wxArrayString &as = sys->dataobjf->GetFilenames();
+
+        if (pdataobjt.GetText() != wxEmptyString) {
+            wxString s = pdataobjt.GetText();
+            if ((sys->clipboardcopy == s) && sys->cellclipboard) {
+                c->Paste(this, sys->cellclipboard.get(), selected);
+                Refresh();
+            } else {
+                const wxArrayString &as = wxStringTokenize(s, LINE_SEPERATOR);
                 if (as.size()) {
-                    if (as.size() > 1) sw->Status(_(L"Cannot drag & drop more than 1 file."));
-                    c->AddUndo(this);
-                    if (!LoadImageIntoCell(as[0], c, sys->frame->csf)) PasteSingleText(c, as[0]);
-                    Refresh();
-                }
-                break;
-            }
-            case wxDF_BITMAP:
-            case wxDF_DIB:
-            case wxDF_TIFF:
-            #ifdef __WXMSW__
-            case wxDF_PNG:
-            #endif
-                if (sys->dataobji->GetBitmap().GetRefData() != wxNullBitmap.GetRefData()) {
-                    c->AddUndo(this);
-                    wxImage im = sys->dataobji->GetBitmap().ConvertToImage();
-                    vector<uint8_t> idv = ConvertWxImageToBuffer(im, wxBITMAP_TYPE_PNG);
-                    SetImageBM(c, std::move(idv), sys->frame->csf);
-                    sys->dataobji->SetBitmap(wxNullBitmap);
-                    c->Reset();
-                    Refresh();
-                }
-                break;
-            /*
-            case wxDF_HTML: {
-                auto s = dataobjh->GetHTML();
-                // Would have to somehow parse HTML here to get images and styled text.
-                break;
-            }
-            case wxDF_RTF: {
-                // Would have to somehow parse RTF here to get images and styled text.
-                break;
-            }
-            */
-            default:  // several text formats
-                if (sys->dataobjt->GetText() != wxEmptyString) {
-                    wxString s = sys->dataobjt->GetText();
-                    if ((sys->clipboardcopy == s) && sys->cellclipboard) {
-                        c->Paste(this, sys->cellclipboard.get(), selected);
-                        Refresh();
+                    if (as.size() <= 1) {
+                        c->AddUndo(this);
+                        c->ResetLayout();
+                        PasteSingleText(c, as[0]);
                     } else {
-                        const wxArrayString &as = wxStringTokenize(s, LINE_SEPERATOR);
-                        if (as.size()) {
-                            if (as.size() <= 1) {
-                                c->AddUndo(this);
-                                c->ResetLayout();
-                                PasteSingleText(c, as[0]);
-                            } else {
-                                c->parent->AddUndo(this);
-                                c->ResetLayout();
-                                DELETEP(c->grid);
-                                sys->FillRows(c->AddGrid(), as, sys->CountCol(as[0]), 0, 0);
-                                if (!c->HasText())
-                                    c->grid->MergeWithParent(c->parent->grid, selected, this);
-                            }
-                            Refresh();
-                        }
+                        c->parent->AddUndo(this);
+                        c->ResetLayout();
+                        DELETEP(c->grid);
+                        sys->FillRows(c->AddGrid(), as, sys->CountCol(as[0]), 0, 0);
+                        if (!c->HasText())
+                            c->grid->MergeWithParent(c->parent->grid, selected, this);
                     }
-                    sys->dataobjt->SetText(wxEmptyString);
+                    Refresh();
                 }
-                break;
+            }
+        }
+
+        if (pdataobjf.GetFilenames().size() != 0) {
+            const wxArrayString &as = pdataobjf.GetFilenames();
+            if (as.size()) {
+                if (as.size() > 1) sw->Status(_(L"Cannot drag & drop more than 1 file."));
+                c->AddUndo(this);
+                if (!LoadImageIntoCell(as[0], c, sys->frame->csf)) PasteSingleText(c, as[0]);
+                Refresh();
+            }
+        }
+
+        if (pdataobji.GetBitmap().GetRefData() != wxNullBitmap.GetRefData()) {
+            c->AddUndo(this);
+            wxImage im = pdataobji.GetBitmap().ConvertToImage();
+            vector<uint8_t> idv = ConvertWxImageToBuffer(im, wxBITMAP_TYPE_PNG);
+            SetImageBM(c, std::move(idv), sys->frame->csf);
+            c->Reset();
+            Refresh();
         }
     }
 

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -789,7 +789,7 @@ struct MyFrame : wxFrame {
             nb->AddPage(sw, _(L"<unnamed>"), true, wxNullBitmap);
         else
             nb->InsertPage(0, sw, _(L"<unnamed>"), true, wxNullBitmap);
-        sw->SetDropTarget(new DropTarget(sys->dataobjc));
+        sw->SetDropTarget(new DropTarget(sys->dndobjc));
         sw->SetFocus();
         return sw;
     }

--- a/src/mywxtools.h
+++ b/src/mywxtools.h
@@ -23,7 +23,7 @@ struct DropTarget : wxDropTarget {
         GetData();
         TSCanvas *sw = sys->frame->GetCurTab();
         sw->SelectClick(x, y, false, 0);
-        sw->doc->PasteOrDrop();
+        sw->doc->PasteOrDrop(*sys->dndobjt, *sys->dndobji, *sys->dndobjf);
         return wxDragCopy;
     }
 };

--- a/src/system.h
+++ b/src/system.h
@@ -81,12 +81,10 @@ struct System {
     uint lastcellcolor = 0xFFFFFF;
     uint lasttextcolor = 0;
     uint lastbordcolor = 0xA0A0A0;
-    wxDataObjectComposite *dataobjc = new wxDataObjectComposite();
-    wxTextDataObject *dataobjt = new wxTextDataObject();
-    wxBitmapDataObject *dataobji = new wxBitmapDataObject();
-    wxFileDataObject *dataobjf = new wxFileDataObject();
-    //wxHTMLDataObject dataobjh;
-    //wxRichTextBufferDataObject dataobjr;
+    wxDataObjectComposite* dndobjc = new wxDataObjectComposite();
+    wxTextDataObject* dndobjt = new wxTextDataObject();
+    wxBitmapDataObject* dndobji = new wxBitmapDataObject();
+    wxFileDataObject* dndobjf = new wxFileDataObject();
 
     System(bool portable)
         : defaultfont(
@@ -145,13 +143,12 @@ struct System {
         cfg->Read(L"casesensitivesearch", &casesensitivesearch, casesensitivesearch);
         cfg->Read(L"defaultfontsize", &g_deftextsize, g_deftextsize);
 
+        dndobjc->Add(dndobjt);
+        dndobjc->Add(dndobji);
+        dndobjc->Add(dndobjf);
+
         // fsw.Connect(wxID_ANY, wxID_ANY, wxEVT_FSWATCHER,
         // wxFileSystemWatcherEventHandler(System::OnFileChanged));
-        dataobjc->Add(dataobjt);
-        dataobjc->Add(dataobji);
-        dataobjc->Add(dataobjf);
-        //dataobjc.Add(dataobjh, true);  // Prefer HTML over text, doesn't seem to work.
-        //dataobjc.Add(dataobjr);
     }
 
     ~System() {


### PR DESCRIPTION
wxDataObjectComposite does not work properly on Wayland for text atoms, so avoid it.

In addition to that, the paste operation wxDataObjects for text, image and file name can be handled completely on the stack.

Only the drag and drop operation still requires an composite data object on the heap, so handle it separately.