### PR TITLE
Keep track of images undergoing manipulation

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -1789,6 +1789,7 @@ struct Document {
                 }
 
                 for(auto c: cellstoresetlayout) {
+                    c->ResetChildren();
                     c->ResetLayout();
                 }
            

--- a/src/document.h
+++ b/src/document.h
@@ -1753,32 +1753,45 @@ struct Document {
             case A_IMAGESCP:
             case A_IMAGESCW:
             case A_IMAGESCF: {
-                long v = 0;
+                std::set<Image *> imagestomanipulate;
+                std::vector<Cell *> cellstoresetlayout;
+                long v = 0.0;
+
                 loopallcellssel(c, true) {
                     if (c->text.image) {
-                        if (!v) {
-                            if (k == A_IMAGESCW) {
-                                v = wxGetNumberFromUser(
-                                    _(L"Please enter the new image width:"),
-                                    _(L"Width"), _(L"Image Resize"), 500, 10, 4000, sys->frame);
-                            } else {
-                                v = wxGetNumberFromUser(
-                                    _(L"Please enter the percentage you want the image scaled by:"),
-                                    L"%", _(L"Image Resize"), 50, 5, 400, sys->frame);
-                            }
-                            if (v < 0) return nullptr;
-                        }
-                        if (k == A_IMAGESCW) {
-                            int pw = c->text.image->pixel_width;
-                            if (pw) c->text.image->ImageRescale((double)v / (double)pw);
-                        } else if (k == A_IMAGESCP) {
-                            c->text.image->ImageRescale(v / 100.0);
-                        } else {
-                            c->text.image->DisplayScale(v / 100.0);
-                        }
-                        c->ResetLayout();
+                        imagestomanipulate.insert(c->text.image);
+                        cellstoresetlayout.push_back(c);
                     }
                 }
+
+                if (imagestomanipulate.size()) {
+                    if (k == A_IMAGESCW) {
+                        v = wxGetNumberFromUser(
+                            _(L"Please enter the new image width:"),
+                            _(L"Width"), _(L"Image Resize"), 500, 10, 4000, sys->frame);
+                    } else {
+                        v = wxGetNumberFromUser(
+                            _(L"Please enter the percentage you want the image scaled by:"),
+                            L"%", _(L"Image Resize"), 50, 5, 400, sys->frame);
+                    }
+                    if (v < 0) return nullptr;
+                }
+
+                for(auto img: imagestomanipulate) {
+                    if (k == A_IMAGESCW) {
+                        int pw = img->pixel_width;
+                        if (pw) img->ImageRescale((double)v / (double)pw);
+                    } else if (k == A_IMAGESCP) {
+                        img->ImageRescale(v / 100.0);
+                    } else {
+                        img->DisplayScale(v / 100.0);
+                    }   
+                }
+
+                for(auto c: cellstoresetlayout) {
+                    c->ResetLayout();
+                }
+           
                 Refresh();
                 return nullptr;
             }

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -74,6 +74,7 @@ WX_DECLARE_STRING_HASH_MAP(bool, wxHashMapBool);
 
 #include <new>
 #include <vector>
+#include <set>
 #include <array>
 #include <string>
 #include <string_view>


### PR DESCRIPTION
Prior to this commit, the image operation got executed on each image in the cells of the selection *per cell*.

The issue was that if the same image was referenced in multiple cells in the selection, the operation was executed per cell, thus on the same image multiple times.

In order to prevent this, keep track of all images and the cells referring to them in the selection, to execute the image operation only once on each image and to reset the layout of the referencing cells.