### PR TITLE
Timestamp style modification

### DIFF
--- a/src/cell.h
+++ b/src/cell.h
@@ -495,6 +495,7 @@ struct Cell {
                 if (grid) grid->bordercolor = color;
                 break;
         }
+        text.WasEdited();
     }
 
     void SetGridTextLayout(int ds, bool vert, bool noset) {

--- a/src/grid.h
+++ b/src/grid.h
@@ -691,7 +691,10 @@ struct Grid {
     void SetStyle(Document *doc, const Selection &s, int sb) {
         cell->AddUndo(doc);
         cell->ResetChildren();
-        foreachcellinsel(c, s) c->text.stylebits ^= sb;
+        foreachcellinsel(c, s) {
+            c->text.stylebits ^= sb;
+            c->text.WasEdited();
+        }
         doc->Refresh();
     }
 


### PR DESCRIPTION
Rationale: I think when I also apply formatting changes that it passes the threshold of being counted as a modification, especially in the case of strikethroughs (e.g. to-dos).