### PR TITLE
Member variables for selection position and length are never negative

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -132,7 +132,7 @@ struct Document {
 
     uint Background() { return rootgrid ? rootgrid->cellcolor : 0xFFFFFF; }
 
-    void InitWith(Cell *r, const wxString &filename, Cell *ics, int xs, int ys) {
+    void InitWith(Cell *r, const wxString &filename, Cell *ics, uint8_t xs, uint8_t ys) {
         rootgrid = r;
         if (ics) {
             Grid *ipg = ics->parent->grid;
@@ -2168,7 +2168,7 @@ struct Document {
         return nullptr;
     }
 
-    void DelRowCol(int &v, int e, int gvs, int dec, int dx, int dy, int nxs, int nys) {
+    void DelRowCol(uint8_t &v, int e, int gvs, int dec, int dx, int dy, int nxs, int nys) {
         if (v != e) {
             selected.g->cell->AddUndo(this);
             if (gvs == 1) {

--- a/src/selection.h
+++ b/src/selection.h
@@ -4,11 +4,11 @@ class Selection {
 
     public:
     Grid *g;
-    int x, y, xs, ys;
+    uint8_t x, y, xs, ys;
     int cursor, cursorend;
     int firstdx, firstdy;
 
-    Selection(Grid *_g = nullptr, int _x = 0, int _y = 0, int _xs = 0, int _ys = 0)
+    Selection(Grid *_g = nullptr, uint8_t _x = 0, uint8_t _y = 0, uint8_t _xs = 0, uint8_t _ys = 0)
         : textedit(false),
           g(_g),
           x(_x),
@@ -125,8 +125,8 @@ class Selection {
         return TEXT_CHAR;
     }
 
-    void Dir(Document *doc, bool ctrl, bool shift, wxDC &dc, int dx, int dy, int &v, int &vs,
-             int &ovs, bool notboundaryperp, bool notboundarypar, bool exitedit) {
+    void Dir(Document *doc, bool ctrl, bool shift, wxDC &dc, int dx, int dy, uint8_t &v, uint8_t &vs,
+             uint8_t &ovs, bool notboundaryperp, bool notboundarypar, bool exitedit) {
         if (ctrl && !textedit) {
             g->cell->AddUndo(doc);
 

--- a/src/system.h
+++ b/src/system.h
@@ -250,7 +250,7 @@ struct System {
             if (strncmp(buf, "TSFF", 4)) return _(L"Not a TreeSheets file.");
             fis.Read(&versionlastloaded, 1);
             if (versionlastloaded > TS_VERSION) return _(L"File of newer version.");
-            int xs, ys;
+            uint8_t xs, ys;
             if (versionlastloaded >= 21) {
                 xs = dis.Read8();
                 ys = dis.Read8();


### PR DESCRIPTION
Use uint8_t. `wxDataOutputStream::Write8(wxUint8)` and `wxDataInputStream::Read8` also uses only unsigned integers.