### PR TITLE
Import and export XML with color attributes in hexadecimal representation

### DIFF
--- a/src/cell.h
+++ b/src/cell.h
@@ -238,12 +238,12 @@ struct Cell {
             }
             if (cellcolor != (parent ? parent->cellcolor : doc->Background())) {
                 str.Prepend(L"\"");
-                str.Prepend(wxString() << cellcolor);
+                str.Prepend(wxString::Format(wxT("0x%06X"), cellcolor));
                 str.Prepend(L" colorbg=\"");
             }
             if (textcolor != (parent ? parent->textcolor : 0x000000)) {
                 str.Prepend(L"\"");
-                str.Prepend(wxString() << textcolor);
+                str.Prepend(wxString::Format(wxT("0x%06X"), textcolor));
                 str.Prepend(L" colorfg=\"");
             }
             if (celltype != CT_DATA) {

--- a/src/system.h
+++ b/src/system.h
@@ -531,8 +531,10 @@ struct System {
         if (n->GetName() == L"cell") {
             c->text.relsize = -wxAtoi(n->GetAttribute(L"relsize", L"0"));
             c->text.stylebits = wxAtoi(n->GetAttribute(L"stylebits", L"0"));
-            c->cellcolor = wxAtoi(n->GetAttribute(L"colorbg", L"16777215"));
-            c->textcolor = wxAtoi(n->GetAttribute(L"colorfg", L"0"));
+            c->cellcolor =
+                std::stoi(n->GetAttribute(L"colorbg", L"0xFFFFFF").ToStdString(), nullptr, 0);
+            c->textcolor =
+                std::stoi(n->GetAttribute(L"colorfg", L"0x000000").ToStdString(), nullptr, 0);
             c->celltype = wxAtoi(n->GetAttribute(L"type", L"0"));
         }
 


### PR DESCRIPTION
Due to the autodetection of the representation, `std::stoi` will convert both the decimal and the hexadecimal representation, thus preserving backwards compatibility.