### PR TITLE
Consistent type naming

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -292,7 +292,7 @@ struct treesheets {
     struct Evaluator;
     struct Image;
     struct Document;
-    class Selection;
+    struct Selection;
 
     struct System;
 


### PR DESCRIPTION
Replace `class` with `struct`. This should have no real-world impact but is more consistent.