### PR TITLE
lobster/tools.h: avoid conflicting define for ssize_t

### DIFF
--- a/lobster/src/lobster/tools.h
+++ b/lobster/src/lobster/tools.h
@@ -25,8 +25,12 @@ typedef int64_t iint;
 // args and indexing, so using the 64-bit type above would introduce a lot
 // of casts. Best we can do is a signed version of that, until we can
 // stop targetting 32-bit entirely.
-// This may also be defined in Posix (sys/types.h), but in C++
-// redefining typedefs is totally cool:
+// This may also be defined in Posix (sys/types.h) or in string.h
+// on Darwin, where it breaks the build. Undefine ssize_t if defined.
+#ifdef ssize_t
+#undef ssize_t
+#endif
+
 typedef ptrdiff_t ssize_t;
 
 // Custom _L suffix, since neither L (different size on win/nix) or LL


### PR DESCRIPTION
@aardappel As I understand, this should be inconsequential where redefining works?
On macOS it may not, since there is a conflicting definition in `string.h`: https://github.com/phracker/MacOSX-SDKs/blob/041600eda65c6a668f66cb7d56b7d1da3e8bcc93/MacOSX10.6.sdk/usr/include/string.h#L70

P. S. If this is not inconsequential for other OS, we can make a fix conditional on Apple.