### PR TITLE
Make hover shadow customizable

### DIFF
--- a/src/grid.h
+++ b/src/grid.h
@@ -357,7 +357,7 @@ struct Grid {
         } else {
             Cell *c = C(s.x, s.y);
             DrawRectangle(dc, bgcol, c->GetX(doc) - cell_margin, c->GetY(doc) - cell_margin,
-                          c->sx + cell_margin * 2, c->sy + cell_margin * 2);
+                          c->sx + cell_margin * 2, c->sy + cell_margin * 2, !sys->hovershadow);
         }
         dc.SetLogicalFunction(wxCOPY);
         #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -229,7 +229,9 @@ enum {
     A_FSWATCH,
     A_DEFBGCOL,
     #ifdef SIMPLERENDER
-    A_DEFCURCOL,
+        A_DEFCURCOL,
+    #else
+        A_HOVERSHADOW,
     #endif
     A_THINSELC,
     A_COPYCT,

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -554,7 +554,10 @@ struct MyFrame : wxFrame {
         MyAppend(optmenu, A_COLCELL, _(L"&Set Custom Color From Cell BG"));
         MyAppend(optmenu, A_DEFBGCOL, _(L"Pick Document Background..."));
         #ifdef SIMPLERENDER
-        MyAppend(optmenu, A_DEFCURCOL, _(L"Pick Cu&rsor Color..."));
+            MyAppend(optmenu, A_DEFCURCOL, _(L"Pick Cu&rsor Color..."));
+        #else
+            optmenu->AppendCheckItem(A_HOVERSHADOW, _(L"Hover shadow"));
+            optmenu->Check(A_HOVERSHADOW, sys->hovershadow);
         #endif
         optmenu->AppendSeparator();
         optmenu->AppendCheckItem(A_SHOWTBAR, _(L"Show Toolbar"));
@@ -993,6 +996,11 @@ struct MyFrame : wxFrame {
             case A_ZOOMSCR: sys->cfg->Write(L"zoomscroll", sys->zoomscroll = ce.IsChecked()); break;
             case A_THINSELC: sys->cfg->Write(L"thinselc", sys->thinselc = ce.IsChecked()); break;
             case A_AUTOSAVE: sys->cfg->Write(L"autosave", sys->autosave = ce.IsChecked()); break;
+            #ifndef SIMPLERENDER
+                case A_HOVERSHADOW:
+                   sys->cfg->Write(L"hovershadow", sys->hovershadow = ce.IsChecked());
+                   break;
+            #endif
             case A_CENTERED:
                 sys->cfg->Write(L"centered", sys->centered = ce.IsChecked());
                 Refresh();

--- a/src/system.h
+++ b/src/system.h
@@ -93,6 +93,9 @@ struct System {
     bool fastrender {true};
     bool showtoolbar {true};
     bool showstatusbar {true};
+    #ifndef SIMPLERENDER
+        bool hovershadow {true};
+    #endif
     int sortcolumn;
     int sortxs;
     int sortdescending;
@@ -140,7 +143,9 @@ struct System {
         cfg->Read(L"defaultfontsize", &g_deftextsize, g_deftextsize);
         cfg->Read(L"customcolor", &customcolor, customcolor);
         #ifdef SIMPLERENDER
-        cfg->Read(L"cursorcolor", &cursorcolor, cursorcolor);
+            cfg->Read(L"cursorcolor", &cursorcolor, cursorcolor);
+        #else
+            cfg->Read(L"hovershadow", &hovershadow, hovershadow);
         #endif
         cfg->Read(L"showtoolbar", &showtoolbar, showtoolbar);
         cfg->Read(L"showstatusbar", &showstatusbar, showstatusbar);


### PR DESCRIPTION
The hover shadow comes with a trade-off:
(+) It gives better orientation with lots of text in a TreeSheets
(-) The hover XORs also bitmaps which can be obstructive when there is lot of works with images
So give the user the choice about the hover shadow.