### PR TITLE
Write option changes directly to the configuration database on disk

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -1169,7 +1169,7 @@ struct Document {
             case A_DEFCURCOL: {
                 uint c = PickColor(sys->frame, sys->cursorcolor);
                 if (c != (uint)-1) {
-                    sys->cursorcolor = c;
+                    sys->cfg->Write(L"cursorcolor", sys->cursorcolor = c);
                     Refresh();
                 }
                 return nullptr;

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -794,7 +794,6 @@ struct MyFrame : wxFrame {
 
     ~MyFrame() {
         filehistory.Save(*sys->cfg);
-        sys->cfg->Write(L"customcolor", sys->customcolor);
         #ifdef SIMPLERENDER
         sys->cfg->Write(L"cursorcolor", sys->cursorcolor);
         #endif
@@ -985,7 +984,7 @@ struct MyFrame : wxFrame {
                 break;
             case A_CUSTCOL: {
                 uint c = PickColor(sys->frame, sys->customcolor);
-                if (c != (uint)-1) sys->customcolor = c;
+                if (c != (uint)-1) sys->cfg->Write(L"customcolor", sys->customcolor = c);
                 break;
             }
             case A_LEFTTABS: Check(L"lefttabs"); break;

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -798,8 +798,6 @@ struct MyFrame : wxFrame {
         #ifdef SIMPLERENDER
         sys->cfg->Write(L"cursorcolor", sys->cursorcolor);
         #endif
-        sys->cfg->Write(L"showtoolbar", sys->showtoolbar);
-        sys->cfg->Write(L"showstatusbar", sys->showstatusbar);
         if (!IsIconized()) {
             sys->cfg->Write(L"maximized", IsMaximized());
             if (!IsMaximized()) {
@@ -967,7 +965,7 @@ struct MyFrame : wxFrame {
 
             case A_SHOWSBAR:
                 if (!IsFullScreen()) {
-                    sys->showstatusbar = !sys->showstatusbar;
+                    sys->cfg->Write(L"showstatusbar", sys->showstatusbar = !sys->showstatusbar);
                     wxStatusBar *wsb = this->GetStatusBar();
                     wsb->Show(sys->showstatusbar);
                     this->SendSizeEvent();
@@ -977,7 +975,7 @@ struct MyFrame : wxFrame {
                 break;
             case A_SHOWTBAR:
                 if (!IsFullScreen()) {
-                    sys->showtoolbar = !sys->showtoolbar;
+                    sys->cfg->Write(L"showtoolbar", sys->showtoolbar = !sys->showtoolbar);
                     wxToolBar *wtb = this->GetToolBar();
                     wtb->Show(sys->showtoolbar);
                     this->SendSizeEvent();

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -794,9 +794,6 @@ struct MyFrame : wxFrame {
 
     ~MyFrame() {
         filehistory.Save(*sys->cfg);
-        #ifdef SIMPLERENDER
-        sys->cfg->Write(L"cursorcolor", sys->cursorcolor);
-        #endif
         if (!IsIconized()) {
             sys->cfg->Write(L"maximized", IsMaximized());
             if (!IsMaximized()) {


### PR DESCRIPTION
Instead of waiting until the MyFrame class is destructed, write directly to local configuration database/file when option is changed.
This makes for a more consistent logic likewise used in similiar scenarios.