### PR TITLE
Generic PickColor

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -2076,12 +2076,6 @@ struct Document {
         return nullptr;
     }
 
-    uint PickColor(wxFrame *fr, uint defcol) {
-        wxColour col = wxGetColourFromUser(fr, wxColour(defcol));
-        if (col.IsOk()) return (col.Blue() << 16) + (col.Green() << 8) + col.Red();
-        return -1;
-    }
-
     const wxChar *layrender(int ds, bool vert, bool toggle = false, bool noset = false) {
         if (selected.Thin()) return NoThin();
         selected.g->cell->AddUndo(this);

--- a/src/document.h
+++ b/src/document.h
@@ -1151,12 +1151,6 @@ struct Document {
             case A_NEXTFILE: sys->frame->CycleTabs(1); return nullptr;
             case A_PREVFILE: sys->frame->CycleTabs(-1); return nullptr;
 
-            case A_CUSTCOL: {
-                uint c = PickColor(sys->frame, sys->customcolor);
-                if (c != (uint)-1) sys->customcolor = c;
-                return nullptr;
-            }
-
             case A_DEFBGCOL: {
                 uint oldbg = Background();
                 uint c = PickColor(sys->frame, oldbg);

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -985,6 +985,11 @@ struct MyFrame : wxFrame {
                     wtb->Refresh();
                 }
                 break;
+            case A_CUSTCOL: {
+                uint c = PickColor(sys->frame, sys->customcolor);
+                if (c != (uint)-1) sys->customcolor = c;
+                break;
+            }
             case A_LEFTTABS: Check(L"lefttabs"); break;
             case A_SINGLETRAY: Check(L"singletray"); break;
             case A_MAKEBAKS: sys->cfg->Write(L"makebaks", sys->makebaks = ce.IsChecked()); break;

--- a/src/mywxtools.h
+++ b/src/mywxtools.h
@@ -110,6 +110,12 @@ struct ColorDropdown : wxOwnerDrawnComboBox {
     }
 };
 
+static uint PickColor(wxFrame *fr, uint defcol) {
+    wxColour col = wxGetColourFromUser(fr, wxColour(defcol));
+    if (col.IsOk()) return (col.Blue() << 16) + (col.Green() << 8) + col.Red();
+    return -1;
+}
+
 #define dd_icon_res_scale 3.0
 
 struct ImagePopup : wxVListBoxComboPopup {


### PR DESCRIPTION
PickColor is not always an operation directly linked to a Document, thus move it out to the generic tools in treesheets class. Move action that sets the option out from Document to MyFrame.