### PR TITLE
Keep relative text size in cells when tag is set

### DIFF
--- a/src/cell.h
+++ b/src/cell.h
@@ -417,7 +417,7 @@ struct Cell {
                 textcolor = c->textcolor;
                 text.stylebits = c->text.stylebits;
             }
-            text.Insert(doc, c->text.t, s);
+            text.Insert(doc, c->text.t, s, false);
         }
         if (c->text.image) text.image = c->text.image;
         if (c->grid) {

--- a/src/document.h
+++ b/src/document.h
@@ -2085,7 +2085,7 @@ struct Document {
         if (!WalkPath(drawpath)->grid) Zoom(-1, dc);
     }
 
-    void PasteSingleText(Cell *c, const wxString &t) { c->text.Insert(this, t, selected); }
+    void PasteSingleText(Cell *c, const wxString &t) { c->text.Insert(this, t, selected, false); }
 
     void PasteOrDrop(const wxTextDataObject &pdataobjt, const wxBitmapDataObject &pdataobji,
                      const wxFileDataObject &pdataobjf) {
@@ -2333,7 +2333,7 @@ struct Document {
                 selected.g->cell->AddUndo(this);
                 loopallcellssel(c, false) {
                     c->text.Clear(this, selected);
-                    c->text.Insert(this, tagit->first, selected);
+                    c->text.Insert(this, tagit->first, selected, true);
                 }
                 selected.g->cell->ResetChildren();
                 selected.g->cell->ResetLayout();

--- a/src/text.h
+++ b/src/text.h
@@ -374,18 +374,18 @@ struct Text {
         }
     }
 
-    void Insert(Document *doc, const wxString &ins, Selection &s) {
+    void Insert(Document *doc, const wxString &ins, Selection &s, bool keeprelsize) {
         auto prevl = t.Len();
         if (!s.TextEdit()) Clear(doc, s);
         RangeSelRemove(s);
-        if (!prevl) SetRelSize(s);
+        if (!prevl && !keeprelsize) SetRelSize(s);
         t.insert(s.cursor, ins);
         s.cursor = s.cursorend = s.cursor + (int)ins.Len();
     }
     void Key(Document *doc, int k, Selection &s) {
         wxString ins;
         ins += k;
-        Insert(doc, ins, s);
+        Insert(doc, ins, s, false);
     }
 
     void Delete(Selection &s) {


### PR DESCRIPTION
When the cell text is cleared and the tag is inserted,
the relative text size shall be kept.

This is especially useful when the tag is replaced by another tag.