### PR TITLE
Make MacOSX Bundle with working translations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,8 +100,15 @@ endif()
 
 add_executable(
     treesheets
+    MACOSX_BUNDLE
     src/main.cpp
 )
+
+if(APPLE)
+    set_target_properties(treesheets PROPERTIES
+        MACOSX_BUNDLE_INFO_PLIST "${CMAKE_SOURCE_DIR}/osx/Info.plist"
+    )
+endif()
 
 target_include_directories(treesheets PUBLIC lobster/src)
 
@@ -142,6 +149,10 @@ if(LINUX AND NOT TREESHEETS_RELOCATABLE_INSTALLATION)
     install(FILES linux/com.strlen.TreeSheets.svg DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/apps)
     install(FILES linux/com.strlen.TreeSheets.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
     install(FILES linux/com.strlen.TreeSheets.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/mime/packages)
+elseif(APPLE)
+    set(TREESHEETS_BINDIR ${CMAKE_INSTALL_PREFIX})
+    set(TREESHEETS_DOCDIR ${CMAKE_INSTALL_PREFIX}/treesheets.app/Contents/Resources)
+    set(TREESHEETS_PKGDATADIR ${CMAKE_INSTALL_PREFIX}/treesheets.app/Contents/Resources)
 else()
     set(TREESHEETS_BINDIR ${CMAKE_INSTALL_PREFIX})
     set(TREESHEETS_DOCDIR ${CMAKE_INSTALL_PREFIX})
@@ -179,7 +190,7 @@ elseif(APPLE)
     foreach(locale ${locales})
         install(
             FILES "TS/translations/${locale}/ts.mo"
-            DESTINATION "${CMAKE_INSTALL_PREFIX}/translations/${locale}.lproj"
+            DESTINATION "${CMAKE_INSTALL_PREFIX}/treesheets.app/Contents/Resources/translations/${locale}.lproj"
         )
     endforeach()
 else()

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Windows:
     the wxWidgets libraries.
 7. To distribute, build an installer with `TS_installer.nsi` (requires nsis.sourceforge.net)
 
-Linux:
+Linux / MacOS X:
 
 1. Configure the build process with `cmake -S . -B _build -DCMAKE_BUILD_TYPE=Release` or similar.
     - If you have `git` installed, the submodules for wxWidgets will be automatically updated and wxWidgets will be compiled as a CMake subproject. TreeSheets will be then statically linked against this wxWidgets build.
@@ -85,20 +85,14 @@ Linux:
         - You can use the version of wxWidgets from https://github.com/wxWidgets/wxWidgets.git.
         - Follow the instructions to build there, but add `--enable-unicode` and `--disable-shared` to the `configure` step.
     - You can change the default installation prefix (`/usr/local`) by passing something like `-DCMAKE_INSTALL_PREFIX=/usr`.
+    - If you are MacOS X user, a bundle will be installed to the installation prefix.
 2. Build using `cmake --build _build`.
 3. Install using `sudo cmake --install _build`.
 
-OSX:
+For Mac OS X users:
 
-1. Build wxWidgets as follows (inside the wxWidgets dir):
-    1. `mkdir build_osx`
-    2. `cd build_osx`
-    3. `../configure --enable-unicode --disable-shared --disable-sys-libs --without-libtiff --with-osx_cocoa --enable-universal_binary=x86_64,arm64 CXXFLAGS="-stdlib=libc++" LDFLAGS="-stdlib=libc++" OBJCXXFLAGS="-stdlib=libc++" --disable-mediactrl CC=clang CXX=clang++`
-    4. `make -j8`
-    5. `sudo make install`
-2. use the XCode project in `osx/TreeSheets` to build treesheets. put the resulting
-  .app together with the files from the `TS` folder in `osx/TreeSheetsBeta` to distribute.
-  Note to use the "Archive" operation to create a release executable.
+4. Run the application bundle that has been installed to the installation prefix. You might consider to drag-and-drop it to Applications.
+
 
 Contributing:
 -------------

--- a/osx/Info.plist
+++ b/osx/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>treesheets</string>
+	<key>CFBundleGetInfoString</key>
+	<string></string>
+	<key>CFBundleIconFile</key>
+	<string>App.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.strlen.TreeSheets</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleLongVersionString</key>
+	<string></string>
+	<key>CFBundleName</key>
+	<string></string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string></string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string></string>
+	<key>CSResourcesFileMapped</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Wouter van Oortmersen</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>English</string>
+		<string>German</string>
+		<string>French</string>
+		<string>Chinese</string>
+		<string>Portuguese</string>
+		<string>Russian</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
- To create bundle, both build and install must be run by CMake
- Localizations now need to be extra declared in Info.plist