### PR TITLE
Assign ALT to Command key on MacOS

### DIFF
--- a/src/mycanvas.h
+++ b/src/mycanvas.h
@@ -112,15 +112,16 @@ struct TSCanvas : public wxScrolledCanvas {
             return;
         }
         */
-
-        // Without this check, Alt+[Alphanumericals], Alt+Shift+[Alphanumericals] and
-        // Alt+[Shift]+cursor (scrolling) don't work. The 128 makes sure unicode entry on e.g.
-        // Polish keyboards still works. (on Linux in particular).
-        if ((ce.GetModifiers() == wxMOD_ALT || ce.GetModifiers() == (wxMOD_ALT | wxMOD_SHIFT)) &&
-            (ce.GetUnicodeKey() < 128)) {
-            ce.Skip();
-            return;
-        }
+        #ifndef __WXMAC__
+            // Without this check, Alt+[Alphanumericals], Alt+Shift+[Alphanumericals] and
+            // Alt+[Shift]+cursor (scrolling) don't work. The 128 makes sure unicode entry on e.g.
+            // Polish keyboards still works. (on Linux in particular).
+            if ((ce.GetModifiers() == wxMOD_ALT || ce.GetModifiers() == (wxMOD_ALT | wxMOD_SHIFT)) &&
+                (ce.GetUnicodeKey() < 128)) {
+                ce.Skip();
+                return;
+            }
+        #endif
 
         wxClientDC dc(this);
         DoPrepareDC(dc);

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -386,20 +386,32 @@ struct MyFrame : wxFrame {
             MyAppend(navmenu, A_BROWSEF, _(L"Open &file\tF4"),
                      _(L"Opens up the text from the selected cell in default application for the file type"));
 
+            #ifdef __WXMAC__
+                #define CTRLORALT "CTRL"
+            #else
+                #define CTRLORALT "ALT"
+            #endif
+
             wxMenu *laymenu = new wxMenu();
-            MyAppend(laymenu, A_V_GS, _(L"Vertical Layout with Grid Style Rendering\tALT+1"));
-            MyAppend(laymenu, A_V_BS, _(L"Vertical Layout with Bubble Style Rendering\tALT+2"));
-            MyAppend(laymenu, A_V_LS, _(L"Vertical Layout with Line Style Rendering\tALT+3"));
+            MyAppend(laymenu, A_V_GS,
+                     _(L"Vertical Layout with Grid Style Rendering\t" CTRLORALT "+1"));
+            MyAppend(laymenu, A_V_BS,
+                     _(L"Vertical Layout with Bubble Style Rendering\t" CTRLORALT "+2"));
+            MyAppend(laymenu, A_V_LS,
+                     _(L"Vertical Layout with Line Style Rendering\t" CTRLORALT "+3"));
             laymenu->AppendSeparator();
-            MyAppend(laymenu, A_H_GS, _(L"Horizontal Layout with Grid Style Rendering\tALT+4"));
-            MyAppend(laymenu, A_H_BS, _(L"Horizontal Layout with Bubble Style Rendering\tALT+5"));
-            MyAppend(laymenu, A_H_LS, _(L"Horizontal Layout with Line Style Rendering\tALT+6"));
+            MyAppend(laymenu, A_H_GS,
+                     _(L"Horizontal Layout with Grid Style Rendering\t" CTRLORALT "+4"));
+            MyAppend(laymenu, A_H_BS,
+                     _(L"Horizontal Layout with Bubble Style Rendering\t" CTRLORALT "+5"));
+            MyAppend(laymenu, A_H_LS,
+                     _(L"Horizontal Layout with Line Style Rendering\t" CTRLORALT "+6"));
             laymenu->AppendSeparator();
-            MyAppend(laymenu, A_GS, _(L"Grid Style Rendering\tALT+7"));
-            MyAppend(laymenu, A_BS, _(L"Bubble Style Rendering\tALT+8"));
-            MyAppend(laymenu, A_LS, _(L"Line Style Rendering\tALT+9"));
+            MyAppend(laymenu, A_GS, _(L"Grid Style Rendering\t" CTRLORALT "+7"));
+            MyAppend(laymenu, A_BS, _(L"Bubble Style Rendering\t" CTRLORALT "+8"));
+            MyAppend(laymenu, A_LS, _(L"Line Style Rendering\t" CTRLORALT "+9"));
             laymenu->AppendSeparator();
-            MyAppend(laymenu, A_TEXTGRID, _(L"Toggle Vertical Layout\tALT+0"),
+            MyAppend(laymenu, A_TEXTGRID, _(L"Toggle Vertical Layout\t" CTRLORALT "+0"),
                      _(L"Make a hierarchy layout more vertical (default) or more horizontal"));
 
             editmenu = new wxMenu();


### PR DESCRIPTION
ALT is translated to Option key on MacOS
but shortcuts with Option + (Shift +) Number are used for characters on macOS. To not block input of characters, assign ALT+Number to CTRL+Number and thus to Command+Number on macOS.