### PR TITLE
Do not trigger reset on DPI change on macOS platform

### DIFF
--- a/src/myevents.h
+++ b/src/myevents.h
@@ -1,6 +1,8 @@
 
 BEGIN_EVENT_TABLE(treesheets::MyFrame, wxFrame)
-  EVT_DPI_CHANGED(treesheets::MyFrame::OnDPIChanged)
+  #ifndef __WXMAC__
+    EVT_DPI_CHANGED(treesheets::MyFrame::OnDPIChanged)
+  #endif
   EVT_SIZING(treesheets::MyFrame::OnSizing)
   EVT_MENU(wxID_ANY, treesheets::MyFrame::OnMenu)
   EVT_TEXT(A_SEARCH, treesheets::MyFrame::OnSearch)


### PR DESCRIPTION
It is not necessary on macOS and moreover creates a segmentation fault.

```
AddressSanitizer:DEADLYSIGNAL
================================================================= ==16564==ERROR: AddressSanitizer: SEGV on unknown address 0xffffd847d7d9d7db (pc 0x000104f52700 bp 0x00016af19a50 sp 0x00016af199c0 T0) ==16564==The signal is caused by a READ memory access.
    #0 0x104f52700 in treesheets::Cell::Reset() cell.h:307
    #1 0x104f51ef8 in treesheets::Cell::ResetChildren() cell.h:309
    #2 0x104ee90d8 in treesheets::MyFrame::OnDPIChanged(wxDPIChangedEvent&) myframe.h:1154
    #3 0x105ebd0d4 in wxAppConsoleBase::HandleEvent(wxEvtHandler*, void (wxEvtHandler::*)(wxEvent&), wxEvent&) const appbase.cpp:644
    #4 0x105ebd4a0 in wxAppConsoleBase::CallEventHandler(wxEvtHandler*, wxEventFunctor&, wxEvent&) const appbase.cpp:656
    #5 0x10624324c in wxEvtHandler::ProcessEventIfMatchesId(wxEventTableEntryBase const&, wxEvtHandler*, wxEvent&) event.cpp:1456
    #6 0x106242b4c in wxEventHashTable::HandleEvent(wxEvent&, wxEvtHandler*) event.cpp:1061
```