### PR TITLE
const char instead of const wchar_t

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -140,7 +140,7 @@ struct Document {
     }
 
     const wxChar *SaveDB(bool *success, bool istempfile = false, int page = -1) {
-        if (filename.empty()) return _(L"Save cancelled.");
+        if (filename.empty()) return _("Save cancelled.");
         Cell *ocs = selected.GetFirst();
         auto start_saving_time = wxGetLocalTimeMillis();
 
@@ -154,9 +154,9 @@ struct Document {
             if (!fos.IsOk()) {
                 if (!istempfile)
                     wxMessageBox(
-                        _(L"Error writing TreeSheets file! (try saving under new filename)."),
+                        _("Error writing TreeSheets file! (try saving under new filename)."),
                         sfn.wx_str(), wxOK, sys->frame);
-                return _(L"Error writing to file.");
+                return _("Error writing to file.");
             }
 
             wxDataOutputStream sos(fos);
@@ -182,7 +182,7 @@ struct Document {
 
             fos.Write("D", 1);
             wxZlibOutputStream zos(fos, 9);
-            if (!zos.IsOk()) return _(L"Zlib error while writing file.");
+            if (!zos.IsOk()) return _("Zlib error while writing file.");
             wxDataOutputStream dos(zos);
             rootgrid->Save(dos, ocs);
             for (auto &tag : tags) { dos.WriteString(tag); }
@@ -205,12 +205,12 @@ struct Document {
         UpdateFileName(page);
         if (success) *success = true;
 
-        sw->Status(wxString::Format(_(L"Saved %s successfully (in %d milliseconds)."),
+        sw->Status(wxString::Format(_("Saved %s successfully (in %d milliseconds)."),
                                     filename.c_str(),
                                     (int)((end_saving_time - start_saving_time).GetValue()))
                        .c_str());
 
-        return _(L"");
+        return _("");
     }
 
     void DrawSelect(wxDC &dc, Selection &s, bool refreshinstead = false, bool cursoronly = false) {
@@ -519,10 +519,10 @@ struct Document {
         DrawSelectMove(dc, selected, true, false);
     }
 
-    const wxChar *NoSel() { return _(L"This operation requires a selection."); }
-    const wxChar *OneCell() { return _(L"This operation works on a single selected cell only."); }
-    const wxChar *NoThin() { return _(L"This operation doesn't work on thin selections."); }
-    const wxChar *NoGrid() { return _(L"This operation requires a cell that contains a grid."); }
+    const wxChar *NoSel() { return _("This operation requires a selection."); }
+    const wxChar *OneCell() { return _("This operation works on a single selected cell only."); }
+    const wxChar *NoThin() { return _("This operation doesn't work on thin selections."); }
+    const wxChar *NoGrid() { return _("This operation requires a cell that contains a grid."); }
 
     const wxChar *Wheel(wxDC &dc, int dir, bool alt, bool ctrl, bool shift,
                         bool hierarchical = true) {
@@ -538,7 +538,7 @@ struct Document {
                 sys->UpdateStatus(selected);
                 scrolltoselection = true;
                 Refresh();
-                return dir > 0 ? _(L"Column width increased.") : _(L"Column width decreased.");
+                return dir > 0 ? _("Column width increased.") : _("Column width decreased.");
             }
             return L"nothing to resize";
         } else if (shift) {
@@ -549,12 +549,12 @@ struct Document {
             sys->UpdateStatus(selected);
             scrolltoselection = true;
             Refresh();
-            return dir > 0 ? _(L"Text size increased.") : _(L"Text size decreased.");
+            return dir > 0 ? _("Text size increased.") : _("Text size decreased.");
         } else if (ctrl) {
             int steps = abs(dir);
             dir = sign(dir);
             loop(i, steps) Zoom(dir, dc);
-            return dir > 0 ? _(L"Zoomed in.") : _(L"Zoomed out.");
+            return dir > 0 ? _("Zoomed in.") : _("Zoomed out.");
         } else {
             ASSERT(0);
             return nullptr;
@@ -731,8 +731,8 @@ struct Document {
     bool CheckForChanges() {
         if (modified) {
             ThreeChoiceDialog tcd(sys->frame, filename,
-                                  _(L"Changes have been made, are you sure you wish to continue?"),
-                                  _(L"Save and Close"), _(L"Discard Changes"), _(L"Cancel"));
+                                  _("Changes have been made, are you sure you wish to continue?"),
+                                  _("Save and Close"), _("Discard Changes"), _("Cancel"));
             switch (tcd.Run()) {
                 case 0: {
                     bool success = false;
@@ -781,7 +781,7 @@ struct Document {
     const wxChar *Export(const wxChar *fmt, const wxChar *pat, const wxChar *msg, int k) {
         wxString fn = ::wxFileSelector(msg, L"", L"", fmt, pat,
                                        wxFD_SAVE | wxFD_OVERWRITE_PROMPT | wxFD_CHANGE_DIR);
-        if (fn.empty()) return _(L"Export cancelled.");
+        if (fn.empty()) return _("Export cancelled.");
         return ExportFile(fn, k, true);
     }
 
@@ -814,17 +814,17 @@ struct Document {
             root->MaxDepthLeaves(0, maxdepth, leaves);
             if (maxdepth > 1)
                 return _(
-                    L"Cannot export grid that is not flat (zoom the view to the desired grid, and/or use Flatten).");
+                    "Cannot export grid that is not flat (zoom the view to the desired grid, and/or use Flatten).");
         }
         if (k == A_EXPIMAGE) {
             wxBitmap bm = GetBitmap();
             Refresh();
-            if (!bm.SaveFile(fn, wxBITMAP_TYPE_PNG)) return _(L"Error writing PNG file!");
+            if (!bm.SaveFile(fn, wxBITMAP_TYPE_PNG)) return _("Error writing PNG file!");
         } else {
             wxFFileOutputStream fos(fn, L"w+b");
             if (!fos.IsOk()) {
-                wxMessageBox(_(L"Error exporting file!"), fn.wx_str(), wxOK, sys->frame);
-                return _(L"Error writing to file!");
+                wxMessageBox(_("Error exporting file!"), fn.wx_str(), wxOK, sys->frame);
+                return _("Error writing to file!");
             }
             wxTextOutputStream dos(fos);
             wxString content = root->ToText(0, Selection(), k, this, true);
@@ -861,15 +861,15 @@ struct Document {
                 case A_EXPTEXT: dos.WriteString(content); break;
             }
         }
-        return _(L"File exported successfully.");
+        return _("File exported successfully.");
     }
 
     const wxChar *Save(bool saveas, bool *success = nullptr) {
         if (!saveas && !filename.empty()) { return SaveDB(success); }
-        wxString fn = ::wxFileSelector(_(L"Choose TreeSheets file to save:"), L"", L"", L"cts",
-                                       _(L"TreeSheets Files (*.cts)|*.cts|All Files (*.*)|*.*"),
+        wxString fn = ::wxFileSelector(_("Choose TreeSheets file to save:"), L"", L"", L"cts",
+                                       _("TreeSheets Files (*.cts)|*.cts|All Files (*.*)|*.*"),
                                        wxFD_SAVE | wxFD_OVERWRITE_PROMPT | wxFD_CHANGE_DIR);
-        if (fn.empty()) return _(L"Save cancelled.");  // avoid name being set to ""
+        if (fn.empty()) return _("Save cancelled.");  // avoid name being set to ""
         ChangeFileName(fn, true);
         return SaveDB(success);
     }
@@ -976,14 +976,14 @@ struct Document {
                 sys->ev.Eval(rootgrid.get());
                 rootgrid->ResetChildren();
                 ClearSelectionRefresh();
-                return _(L"Evaluation finished.");
+                return _("Evaluation finished.");
 
             case wxID_UNDO:
                 if (undolist.size()) {
                     Undo(dc, undolist, redolist);
                     return nullptr;
                 } else {
-                    return _(L"Nothing more to undo.");
+                    return _("Nothing more to undo.");
                 }
 
             case wxID_REDO:
@@ -991,20 +991,20 @@ struct Document {
                     Undo(dc, redolist, undolist, true);
                     return nullptr;
                 } else {
-                    return _(L"Nothing more to redo.");
+                    return _("Nothing more to redo.");
                 }
 
             case wxID_SAVE: return Save(false);
             case wxID_SAVEAS: return Save(true);
             case A_SAVEALL: sys->SaveAll(); return nullptr;
 
-            case A_EXPXML: return Export(L"xml", L"*.xml", _(L"Choose XML file to write"), k);
+            case A_EXPXML: return Export(L"xml", L"*.xml", _("Choose XML file to write"), k);
             case A_EXPHTMLT:
             case A_EXPHTMLB:
-            case A_EXPHTMLO: return Export(L"html", L"*.html", _(L"Choose HTML file to write"), k);
-            case A_EXPTEXT: return Export(L"txt", L"*.txt", _(L"Choose Text file to write"), k);
-            case A_EXPIMAGE: return Export(L"png", L"*.png", _(L"Choose PNG file to write"), k);
-            case A_EXPCSV: return Export(L"csv", L"*.csv", _(L"Choose CSV file to write"), k);
+            case A_EXPHTMLO: return Export(L"html", L"*.html", _("Choose HTML file to write"), k);
+            case A_EXPTEXT: return Export(L"txt", L"*.txt", _("Choose Text file to write"), k);
+            case A_EXPIMAGE: return Export(L"png", L"*.png", _("Choose PNG file to write"), k);
+            case A_EXPCSV: return Export(L"csv", L"*.csv", _("Choose CSV file to write"), k);
 
             case A_IMPXML:
             case A_IMPXMLA:
@@ -1015,8 +1015,8 @@ struct Document {
 
             case wxID_OPEN: {
                 wxString fn = ::wxFileSelector(
-                    _(L"Please select a TreeSheets file to load:"), L"", L"", L"cts",
-                    _(L"TreeSheets Files (*.cts)|*.cts|All Files (*.*)|*.*"),
+                    _("Please select a TreeSheets file to load:"), L"", L"", L"cts",
+                    _("TreeSheets Files (*.cts)|*.cts|All Files (*.*)|*.*"),
                     wxFD_OPEN | wxFD_FILE_MUST_EXIST | wxFD_CHANGE_DIR);
                 return sys->Open(fn);
             }
@@ -1039,9 +1039,9 @@ struct Document {
 
             case wxID_NEW: {
                 int size =
-                    (int)::wxGetNumberFromUser(_(L"What size grid would you like to start with?"),
-                                               _(L"size:"), _(L"New Sheet"), 10, 1, 25, sys->frame);
-                if (size < 0) return _(L"New file cancelled.");
+                    (int)::wxGetNumberFromUser(_("What size grid would you like to start with?"),
+                                               _("size:"), _("New Sheet"), 10, 1, 25, sys->frame);
+                if (size < 0) return _("New file cancelled.");
                 sys->InitDB(size);
                 sys->frame->GetCurTab()->doc->Refresh();
                 return nullptr;
@@ -1054,7 +1054,7 @@ struct Document {
                 info.SetCopyright(L"(C) 2009 Wouter van Oortmerssen");
                 wxString desc = wxString::Format(
                     L"%s\n\n%s " wxVERSION_STRING,
-                    _(L"The Free Form Hierarchical Information Organizer"), _(L"Uses"));
+                    _("The Free Form Hierarchical Information Organizer"), _("Uses"));
                 info.SetDescription(desc);
                 wxAboutBox(info);
                 return nullptr;
@@ -1116,8 +1116,8 @@ struct Document {
 
             case A_PRINTSCALE: {
                 printscale = (uint)::wxGetNumberFromUser(
-                    _(L"How many pixels wide should a page be? (0 for auto fit)"), _(L"scale:"),
-                    _(L"Set Print Scale"), 0, 0, 5000, sys->frame);
+                    _("How many pixels wide should a page be? (0 for auto fit)"), _("scale:"),
+                    _("Set Print Scale"), 0, 0, 5000, sys->frame);
                 return nullptr;
             }
 
@@ -1126,7 +1126,7 @@ struct Document {
                 wxPrintPreview *preview = new wxPrintPreview(
                     new MyPrintout(this), new MyPrintout(this), &printDialogData);
                 wxPreviewFrame *pframe = new wxPreviewFrame(
-                    preview, sys->frame, _(L"Print Preview"), wxPoint(100, 100), wxSize(600, 650));
+                    preview, sys->frame, _("Print Preview"), wxPoint(100, 100), wxSize(600, 650));
                 pframe->Centre(wxBOTH);
                 pframe->Initialize();
                 pframe->Show(true);
@@ -1175,12 +1175,12 @@ struct Document {
                 if (sys->searchstring.Len()) return SearchNext(dc, false, true, k == A_SEARCHPREV);
                 if (Cell *c = selected.GetCell()) {
                     wxString str = c->text.ToText(0, selected, A_EXPTEXT);
-                    if (!str.Len()) return _(L"No text to search for.");
+                    if (!str.Len()) return _("No text to search for.");
                     sys->frame->filter->SetFocus();
                     sys->frame->filter->SetValue(str);
                     return nullptr;
                 } else {
-                    return _(L"You need to select one cell if you want to search for its text.");
+                    return _("You need to select one cell if you want to search for its text.");
                 }
             }
 
@@ -1220,7 +1220,7 @@ struct Document {
             case A_REPLACEONCE:
             case A_REPLACEONCEJ:
             case A_REPLACEALL: {
-                if (!sys->searchstring.Len()) return _(L"No search.");
+                if (!sys->searchstring.Len()) return _("No search.");
                 wxString replaces = sys->frame->replaces->GetValue();
                 wxString lreplaces =
                     sys->casesensitivesearch ? (wxString)wxEmptyString : replaces.Lower();
@@ -1234,7 +1234,7 @@ struct Document {
                     selected.g->ReplaceStr(this, replaces, lreplaces, selected);
                     if (k == A_REPLACEONCEJ) return SearchNext(dc, false, true, false);
                 }
-                return _(L"Text has been replaced.");
+                return _("Text has been replaced.");
             }
 
             case A_CLEARREPLACE: {
@@ -1253,8 +1253,8 @@ struct Document {
                 scaledviewingmode = !scaledviewingmode;
                 rootgrid->ResetChildren();
                 Refresh();
-                return scaledviewingmode ? _(L"Now viewing TreeSheet to fit to the screen exactly, press F12 to return to normal.")
-                                         : _(L"1:1 scale restored.");
+                return scaledviewingmode ? _("Now viewing TreeSheet to fit to the screen exactly, press F12 to return to normal.")
+                                         : _("1:1 scale restored.");
 
             case A_FILTERRANGE: {
                 DateTimeRangeDialog rd(sys->frame);
@@ -1292,9 +1292,9 @@ struct Document {
             case A_SHOWSTATS: {
                 int numcells = 0, textbytes = 0;
                 selected.g->GetStats(selected, numcells, textbytes);
-                sw->Status(wxString::Format(_(L"Selection contains %d cell(s) with %d character(s)."),
+                sw->Status(wxString::Format(_("Selection contains %d cell(s) with %d character(s)."),
                                     numcells, textbytes));
-                return _(L"");
+                return _("");
             }
 
             case A_CUSTKEY: {
@@ -1305,23 +1305,23 @@ struct Document {
                     keys.push_back(it->second);
                 }
                 wxSingleChoiceDialog choice(
-                    sys->frame, _(L"Please pick a menu item to change the key binding for"),
-                    _(L"Key binding"), strs);
+                    sys->frame, _("Please pick a menu item to change the key binding for"),
+                    _("Key binding"), strs);
                 choice.SetSize(wxSize(500, 700));
                 choice.Centre();
                 if (choice.ShowModal() == wxID_OK) {
                     int sel = choice.GetSelection();
                     wxTextEntryDialog textentry(sys->frame,
-                                                _(L"Please enter the new key binding string"),
-                                                _(L"Key binding"), keys[sel]);
+                                                _("Please enter the new key binding string"),
+                                                _("Key binding"), keys[sel]);
                     if (textentry.ShowModal() == wxID_OK) {
                         wxString key = textentry.GetValue();
                         sys->frame->menustrings[strs[sel]] = key;
                         sys->cfg->Write(strs[sel], key);
-                        return _(L"NOTE: key binding will take effect next run of TreeSheets.");
+                        return _("NOTE: key binding will take effect next run of TreeSheets.");
                     }
                 }
-                return _(L"Keybinding cancelled.");
+                return _("Keybinding cancelled.");
             }
         }
 
@@ -1384,7 +1384,7 @@ struct Document {
             case A_COPYCT:
                 if (selected.Thin()) return NoThin();
                 if (selected.TextEdit()) {
-                    if (selected.cursor == selected.cursorend) return _(L"No text selected.");
+                    if (selected.cursor == selected.cursorend) return _("No text selected.");
                 }
                 Copy(k);
                 if (k == wxID_CUT) {
@@ -1405,17 +1405,17 @@ struct Document {
                 if (wxTheClipboard->Open()) {
                     wxTheClipboard->SetData(new wxBitmapDataObject(GetSubBitmap(selected)));
                     wxTheClipboard->Close();
-                    return _(L"Bitmap copied to clipboard");
+                    return _("Bitmap copied to clipboard");
                 }
                 return nullptr;
 
             case A_COLLAPSE: {
                 if (selected.xs * selected.ys == 1)
-                    return _(L"More than one cell must be selected.");
+                    return _("More than one cell must be selected.");
                 auto fc = selected.GetFirst();
                 wxString ct = "";
                 loopallcellssel(ci, true) if (ci != fc && ci->text.t.Len()) ct += " " + ci->text.t;
-                if (!fc->HasContent() && !ct.Len()) return _(L"There is no content to collapse.");
+                if (!fc->HasContent() && !ct.Len()) return _("There is no content to collapse.");
                 fc->parent->AddUndo(this);
                 fc->text.t += ct;
                 loopallcellssel(ci, false) if (ci != fc) ci->Clear();
@@ -1534,7 +1534,7 @@ struct Document {
                 return nullptr;
 
             case A_PASTESTYLE:
-                if (!sys->cellclipboard) return _(L"No style to paste.");
+                if (!sys->cellclipboard) return _("No style to paste.");
                 selected.g->cell->AddUndo(this);
                 selected.g->SetStyles(selected, sys->cellclipboard.get());
                 selected.g->cell->ResetChildren();
@@ -1560,7 +1560,7 @@ struct Document {
             case A_IMAGE: {
                 if (!(c = selected.ThinExpand(this))) return OneCell();
                 wxString fn =
-                    ::wxFileSelector(_(L"Please select an image file:"), L"", L"", L"", L"*.*",
+                    ::wxFileSelector(_("Please select an image file:"), L"", L"", L"", L"*.*",
                                      wxFD_OPEN | wxFD_FILE_MUST_EXIST | wxFD_CHANGE_DIR);
                 c->AddUndo(this);
                 LoadImageIntoCell(fn, c, sys->frame->FromDIP(1.0));
@@ -1693,12 +1693,12 @@ struct Document {
                 }
                 if (imagestomanipulate.empty()) return nullptr;
                 if (k == A_IMAGESCW) {
-                    v = wxGetNumberFromUser(_(L"Please enter the new image width:"), _(L"Width"),
-                                            _(L"Image Resize"), 500, 10, 4000, sys->frame);
+                    v = wxGetNumberFromUser(_("Please enter the new image width:"), _("Width"),
+                                            _("Image Resize"), 500, 10, 4000, sys->frame);
                 } else {
                     v = wxGetNumberFromUser(
-                        _(L"Please enter the percentage you want the image scaled by:"), L"%",
-                        _(L"Image Resize"), 50, 5, 400, sys->frame);
+                        _("Please enter the percentage you want the image scaled by:"), L"%",
+                        _("Image Resize"), 50, 5, 400, sys->frame);
                 }
                 if (v < 0) return nullptr;
                 for (auto img : imagestomanipulate) {
@@ -1735,10 +1735,10 @@ struct Document {
                     if (tim) {
                         if (!oimgfn) {  // first encounter
                             oimgfn = ::wxFileSelector(
-                                _(L"Choose image file to save:"), L"", L"", L"png|jpg",
-                                _(L"PNG file (*.png)|*.png|JPEG file (*.jpg)|*.jpg|All Files (*.*)|*.*"),
+                                _("Choose image file to save:"), L"", L"", L"png|jpg",
+                                _("PNG file (*.png)|*.png|JPEG file (*.jpg)|*.jpg|All Files (*.*)|*.*"),
                                 wxFD_SAVE | wxFD_OVERWRITE_PROMPT | wxFD_CHANGE_DIR);
-                            if (oimgfn.empty()) return _(L"Save cancelled.");
+                            if (oimgfn.empty()) return _("Save cancelled.");
                             counterpos = oimgfn.find_last_of(".");
                             // If file extension is not provided
                             if (counterpos == string::npos) { counterpos = oimgfn.Len(); }
@@ -1750,9 +1750,9 @@ struct Document {
                         wxFFileOutputStream imagefs(imgfn, L"w+b");
                         if (!imagefs.IsOk()) {
                             wxMessageBox(
-                                _(L"Error writing image file! (try saving under new filename)."),
+                                _("Error writing image file! (try saving under new filename)."),
                                 imgfn.wx_str(), wxOK, sys->frame);
-                            return _(L"Error writing to file.");
+                            return _("Error writing to file.");
                         }
                         imagefs.Write(tim->image_data.data(), tim->image_data.size());
                         counter++;
@@ -1798,11 +1798,11 @@ struct Document {
                 int counter = 0;
                 loopallcellssel(c, false) {
                     if (counter >= g_max_launches) {
-                        returnmessage = _(L"Maximum number of launches reached.");
+                        returnmessage = _("Maximum number of launches reached.");
                         break;
                     }
                     if (!wxLaunchDefaultBrowser(c->text.ToText(0, selected, A_EXPTEXT))) {
-                        returnmessage = _(L"The browser could not open at least one link.");
+                        returnmessage = _("The browser could not open at least one link.");
                     } else {
                         counter++;
                     }
@@ -1815,14 +1815,14 @@ struct Document {
                 int counter = 0;
                 loopallcellssel(c, false) {
                     if (counter >= g_max_launches) {
-                        returnmessage = _(L"Maximum number of launches reached.");
+                        returnmessage = _("Maximum number of launches reached.");
                         break;
                     }
                     wxString f = c->text.ToText(0, selected, A_EXPTEXT);
                     wxFileName fn(f);
                     if (fn.IsRelative()) fn.MakeAbsolute(wxFileName(filename).GetPath());
                     if (!wxLaunchDefaultApplication(fn.GetFullPath())) {
-                        returnmessage = _(L"At least one file could not be opened.");
+                        returnmessage = _("At least one file could not be opened.");
                     } else {
                         counter++;
                     }
@@ -1864,7 +1864,7 @@ struct Document {
                     if (!ac->grid) return NoGrid();
                     if (!ac->grid->IsTable())
                         return _(
-                            L"Selected grid is not a table: cells must not already have sub-grids.");
+                            "Selected grid is not a table: cells must not already have sub-grids.");
                     ac->AddUndo(this);
                     ac->grid->Hierarchify(this);
                     ac->ResetChildren();
@@ -1905,14 +1905,14 @@ struct Document {
             case A_LINKREV:
             case A_LINKIMGREV: {
                 if ((k == A_LINK || k == A_LINKREV) && !c->text.t.Len())
-                    return _(L"No text in this cell.");
+                    return _("No text in this cell.");
                 if ((k == A_LINKIMG || k == A_LINKIMGREV) && !c->text.image)
-                    return _(L"No image in this cell.");
+                    return _("No image in this cell.");
                 bool t1 = false, t2 = false;
                 Cell *link =
                     rootgrid->FindLink(selected, c, nullptr, t1, t2, k == A_LINK || k == A_LINKIMG,
                                        k == A_LINKIMG || k == A_LINKIMGREV);
-                if (!link || !link->parent) return _(L"No matching cell found!");
+                if (!link || !link->parent) return _("No matching cell found!");
                 SetSelect(link->parent->grid->FindCell(link));
                 ScrollOrZoom(dc, true);
                 return nullptr;
@@ -1922,11 +1922,11 @@ struct Document {
 
             case A_HSWAP: {
                 Cell *pp = c->parent->parent;
-                if (!pp) return _(L"Cannot move this cell up in the hierarchy.");
+                if (!pp) return _("Cannot move this cell up in the hierarchy.");
                 if (pp->grid->xs != 1 && pp->grid->ys != 1)
-                    return _(L"Can only move this cell into a Nx1 or 1xN grid.");
+                    return _("Can only move this cell into a Nx1 or 1xN grid.");
                 if (c->parent->grid->xs != 1 && c->parent->grid->ys != 1)
-                    return _(L"Can only move this cell from a Nx1 or 1xN grid.");
+                    return _("Can only move this cell from a Nx1 or 1xN grid.");
                 pp->AddUndo(this);
                 SetSelect(pp->grid->HierarchySwap(c->text.t));
                 pp->ResetChildren();
@@ -1944,14 +1944,14 @@ struct Document {
             case A_FILTERMATCHNEXT:
                 bool lastsel = true;
                 Cell *next = rootgrid->FindNextFilterMatch(nullptr, selected.GetCell(), lastsel);
-                if (!next) return _(L"No matches for filter.");
+                if (!next) return _("No matches for filter.");
                 if (next->parent) SetSelect(next->parent->grid->FindCell(next));
                 sw->SetFocus();
                 ScrollOrZoom(dc, true);
                 return nullptr;
         }
 
-        if (!selected.TextEdit()) return _(L"only works in cell text mode");
+        if (!selected.TextEdit()) return _("only works in cell text mode");
 
         switch (k) {
             case A_CANCELEDIT:
@@ -1991,18 +1991,18 @@ struct Document {
                 DrawSelectMove(dc, selected);
                 return nullptr;
             }
-            default: return _(L"Internal error: unimplemented operation!");
+            default: return _("Internal error: unimplemented operation!");
         }
     }
 
     const wxChar *SearchNext(wxDC &dc, bool focusmatch, bool jump, bool reverse) {
         if (!rootgrid) return nullptr;  // fix crash when opening new doc
-        if (!sys->searchstring.Len()) return _(L"No search string.");
+        if (!sys->searchstring.Len()) return _("No search string.");
         bool lastsel = true;
         Cell *next = rootgrid->FindNextSearchMatch(sys->searchstring, nullptr, selected.GetCell(),
                                                    lastsel, reverse);
         sys->frame->SetSearchTextBoxBackgroundColour(next);
-        if (!next) return _(L"No matches for search.");
+        if (!next) return _("No matches for search.");
         if (!jump) return nullptr;
         SetSelect(next->parent->grid->FindCell(next));
         if (focusmatch) sw->SetFocus();
@@ -2031,7 +2031,7 @@ struct Document {
         if (fdo.GetFilenames().size() != 0) {
             const wxArrayString &as = fdo.GetFilenames();
             if (as.size()) {
-                if (as.size() > 1) sw->Status(_(L"Cannot drag & drop more than 1 file."));
+                if (as.size() > 1) sw->Status(_("Cannot drag & drop more than 1 file."));
                 else {
                     wxString fpath = as[0];
                     wxFFileInputStream fis(fpath);
@@ -2040,9 +2040,9 @@ struct Document {
                         fis.Read(buf, 4);
                         if (!strncmp(buf, "TSFF", 4)) {
                             ThreeChoiceDialog tcd(sys->frame, fpath,
-                                                  _(L"It seems that you are about to drop a TreeSheets file. What would you like to do?"),
-                                                  _(L"Open TreeSheets file"), _(L"Paste file path"),
-                                                  _(L"Cancel"));
+                                                  _("It seems that you are about to drop a TreeSheets file. What would you like to do?"),
+                                                  _("Open TreeSheets file"), _("Paste file path"),
+                                                  _("Cancel"));
                             switch (tcd.Run()) {
                                 case 0: sw->Status(sys->LoadDB(fpath));
                                 case 2: return;
@@ -2110,7 +2110,7 @@ struct Document {
     const wxChar *Sort(bool descending) {
         if (selected.xs != 1 && selected.ys <= 1)
             return _(
-                L"Can't sort: make a 1xN selection to indicate what column to sort on, and what rows to affect");
+                "Can't sort: make a 1xN selection to indicate what column to sort on, and what rows to affect");
         selected.g->cell->AddUndo(this);
         selected.g->Sort(selected, descending);
         Refresh();

--- a/src/myframe.h
+++ b/src/myframe.h
@@ -127,8 +127,8 @@ struct MyFrame : wxFrame {
             #endif
         );
         if (!icon.IsOk() || !iconbig.IsOk()) {
-            wxMessageBox(_(L"Error loading core data file (TreeSheets not installed correctly?)"),
-                         _(L"Initialization Error"), wxOK, this);
+            wxMessageBox(_("Error loading core data file (TreeSheets not installed correctly?)"),
+                         _("Initialization Error"), wxOK, this);
             exit(1);
         }
         icons.AddIcon(icon);
@@ -157,234 +157,234 @@ struct MyFrame : wxFrame {
         filehistory.Load(*sys->cfg);
 
         wxMenu *expmenu = new wxMenu();
-        MyAppend(expmenu, A_EXPXML, _(L"&XML..."),
-                 _(L"Export the current view as XML (which can also be reimported without losing structure)"));
-        MyAppend(expmenu, A_EXPHTMLT, _(L"&HTML (Tables+Styling)..."),
-                 _(L"Export the current view as HTML using nested tables, that will look somewhat like the TreeSheet"));
-        MyAppend(expmenu, A_EXPHTMLB, _(L"HTML (&Bullet points)..."),
-                 _(L"Export the current view as HTML as nested bullet points."));
-        MyAppend(expmenu, A_EXPHTMLO, _(L"HTML (&Outline)..."),
-                 _(L"Export the current view as HTML as nested headers, suitable for importing into Word's outline mode"));
+        MyAppend(expmenu, A_EXPXML, _("&XML..."),
+                 _("Export the current view as XML (which can also be reimported without losing structure)"));
+        MyAppend(expmenu, A_EXPHTMLT, _("&HTML (Tables+Styling)..."),
+                 _("Export the current view as HTML using nested tables, that will look somewhat like the TreeSheet"));
+        MyAppend(expmenu, A_EXPHTMLB, _("HTML (&Bullet points)..."),
+                 _("Export the current view as HTML as nested bullet points."));
+        MyAppend(expmenu, A_EXPHTMLO, _("HTML (&Outline)..."),
+                 _("Export the current view as HTML as nested headers, suitable for importing into Word's outline mode"));
         MyAppend(
-            expmenu, A_EXPTEXT, _(L"Indented &Text..."),
-            _(L"Export the current view as tree structured text, using spaces for each indentation level. Suitable for importing into mindmanagers and general text programs"));
+            expmenu, A_EXPTEXT, _("Indented &Text..."),
+            _("Export the current view as tree structured text, using spaces for each indentation level. Suitable for importing into mindmanagers and general text programs"));
         MyAppend(
-            expmenu, A_EXPCSV, _(L"&Comma delimited text (CSV)..."),
-            _(L"Export the current view as CSV. Good for spreadsheets and databases. Only works on grids with no sub-grids (use the Flatten operation first if need be)"));
-        MyAppend(expmenu, A_EXPIMAGE, _(L"&Image..."),
-                 _(L"Export the current view as an image. Useful for faithful renderings of the TreeSheet, and programs that don't accept any of the above options"));
+            expmenu, A_EXPCSV, _("&Comma delimited text (CSV)..."),
+            _("Export the current view as CSV. Good for spreadsheets and databases. Only works on grids with no sub-grids (use the Flatten operation first if need be)"));
+        MyAppend(expmenu, A_EXPIMAGE, _("&Image..."),
+                 _("Export the current view as an image. Useful for faithful renderings of the TreeSheet, and programs that don't accept any of the above options"));
 
         wxMenu *impmenu = new wxMenu();
-        MyAppend(impmenu, A_IMPXML, _(L"XML..."));
-        MyAppend(impmenu, A_IMPXMLA, _(L"XML (attributes too, for OPML etc)..."));
-        MyAppend(impmenu, A_IMPTXTI, _(L"Indented text..."));
-        MyAppend(impmenu, A_IMPTXTC, _(L"Comma delimited text (CSV)..."));
-        MyAppend(impmenu, A_IMPTXTS, _(L"Semi-Colon delimited text (CSV)..."));
-        MyAppend(impmenu, A_IMPTXTT, _(L"Tab delimited text..."));
+        MyAppend(impmenu, A_IMPXML, _("XML..."));
+        MyAppend(impmenu, A_IMPXMLA, _("XML (attributes too, for OPML etc)..."));
+        MyAppend(impmenu, A_IMPTXTI, _("Indented text..."));
+        MyAppend(impmenu, A_IMPTXTC, _("Comma delimited text (CSV)..."));
+        MyAppend(impmenu, A_IMPTXTS, _("Semi-Colon delimited text (CSV)..."));
+        MyAppend(impmenu, A_IMPTXTT, _("Tab delimited text..."));
 
         wxMenu *recentmenu = new wxMenu();
         filehistory.UseMenu(recentmenu);
         filehistory.AddFilesToMenu();
 
         wxMenu *filemenu = new wxMenu();
-        MyAppend(filemenu, wxID_NEW, _(L"&New\tCTRL+n"));
-        MyAppend(filemenu, wxID_OPEN, _(L"&Open...\tCTRL+o"));
-        MyAppend(filemenu, wxID_CLOSE, _(L"&Close\tCTRL+w"));
-        filemenu->AppendSubMenu(recentmenu, _(L"&Recent files"));
-        MyAppend(filemenu, wxID_SAVE, _(L"&Save\tCTRL+s"));
-        MyAppend(filemenu, wxID_SAVEAS, _(L"Save &As..."));
-        MyAppend(filemenu, A_SAVEALL, _(L"Save All"));
+        MyAppend(filemenu, wxID_NEW, _("&New\tCTRL+n"));
+        MyAppend(filemenu, wxID_OPEN, _("&Open...\tCTRL+o"));
+        MyAppend(filemenu, wxID_CLOSE, _("&Close\tCTRL+w"));
+        filemenu->AppendSubMenu(recentmenu, _("&Recent files"));
+        MyAppend(filemenu, wxID_SAVE, _("&Save\tCTRL+s"));
+        MyAppend(filemenu, wxID_SAVEAS, _("Save &As..."));
+        MyAppend(filemenu, A_SAVEALL, _("Save All"));
         filemenu->AppendSeparator();
-        MyAppend(filemenu, A_PAGESETUP, _(L"Page Setup..."));
-        MyAppend(filemenu, A_PRINTSCALE, _(L"Set Print Scale..."));
-        MyAppend(filemenu, wxID_PREVIEW, _(L"Print preview..."));
-        MyAppend(filemenu, wxID_PRINT, _(L"&Print...\tCTRL+p"));
+        MyAppend(filemenu, A_PAGESETUP, _("Page Setup..."));
+        MyAppend(filemenu, A_PRINTSCALE, _("Set Print Scale..."));
+        MyAppend(filemenu, wxID_PREVIEW, _("Print preview..."));
+        MyAppend(filemenu, wxID_PRINT, _("&Print...\tCTRL+p"));
         filemenu->AppendSeparator();
-        filemenu->AppendSubMenu(expmenu, _(L"Export &view as"));
-        filemenu->AppendSubMenu(impmenu, _(L"Import file from"));
+        filemenu->AppendSubMenu(expmenu, _("Export &view as"));
+        filemenu->AppendSubMenu(impmenu, _("Import file from"));
         filemenu->AppendSeparator();
-        MyAppend(filemenu, wxID_EXIT, _(L"&Exit\tCTRL+q"));
+        MyAppend(filemenu, wxID_EXIT, _("&Exit\tCTRL+q"));
 
         wxMenu *editmenu;
         loop(twoeditmenus, 2) {
             wxMenu *sizemenu = new wxMenu();
-            MyAppend(sizemenu, A_INCSIZE, _(L"&Increase text size (SHIFT+mousewheel)\tSHIFT+PGUP"));
-            MyAppend(sizemenu, A_DECSIZE, _(L"&Decrease text size (SHIFT+mousewheel)\tSHIFT+PGDN"));
-            MyAppend(sizemenu, A_RESETSIZE, _(L"&Reset text sizes\tCTRL+SHIFT+s"));
-            MyAppend(sizemenu, A_MINISIZE, _(L"&Shrink text of all sub-grids\tCTRL+SHIFT+m"));
+            MyAppend(sizemenu, A_INCSIZE, _("&Increase text size (SHIFT+mousewheel)\tSHIFT+PGUP"));
+            MyAppend(sizemenu, A_DECSIZE, _("&Decrease text size (SHIFT+mousewheel)\tSHIFT+PGDN"));
+            MyAppend(sizemenu, A_RESETSIZE, _("&Reset text sizes\tCTRL+SHIFT+s"));
+            MyAppend(sizemenu, A_MINISIZE, _("&Shrink text of all sub-grids\tCTRL+SHIFT+m"));
             sizemenu->AppendSeparator();
-            MyAppend(sizemenu, A_INCWIDTH, _(L"Increase column width (ALT+mousewheel)\tALT+PGUP"));
-            MyAppend(sizemenu, A_DECWIDTH, _(L"Decrease column width (ALT+mousewheel)\tALT+PGDN"));
+            MyAppend(sizemenu, A_INCWIDTH, _("Increase column width (ALT+mousewheel)\tALT+PGUP"));
+            MyAppend(sizemenu, A_DECWIDTH, _("Decrease column width (ALT+mousewheel)\tALT+PGDN"));
             MyAppend(sizemenu, A_INCWIDTHNH,
-                     _(L"Increase column width (no sub grids)\tCTRL+ALT+PGUP"));
+                     _("Increase column width (no sub grids)\tCTRL+ALT+PGUP"));
             MyAppend(sizemenu, A_DECWIDTHNH,
-                     _(L"Decrease column width (no sub grids)\tCTRL+ALT+PGDN"));
-            MyAppend(sizemenu, A_RESETWIDTH, _(L"Reset column widths\tCTRL+SHIFT+w"));
+                     _("Decrease column width (no sub grids)\tCTRL+ALT+PGDN"));
+            MyAppend(sizemenu, A_RESETWIDTH, _("Reset column widths\tCTRL+SHIFT+w"));
 
             wxMenu *bordmenu = new wxMenu();
-            MyAppend(bordmenu, A_BORD0, _(L"Border &0\tCTRL+SHIFT+9"));
-            MyAppend(bordmenu, A_BORD1, _(L"Border &1\tCTRL+SHIFT+1"));
-            MyAppend(bordmenu, A_BORD2, _(L"Border &2\tCTRL+SHIFT+2"));
-            MyAppend(bordmenu, A_BORD3, _(L"Border &3\tCTRL+SHIFT+3"));
-            MyAppend(bordmenu, A_BORD4, _(L"Border &4\tCTRL+SHIFT+4"));
-            MyAppend(bordmenu, A_BORD5, _(L"Border &5\tCTRL+SHIFT+5"));
+            MyAppend(bordmenu, A_BORD0, _("Border &0\tCTRL+SHIFT+9"));
+            MyAppend(bordmenu, A_BORD1, _("Border &1\tCTRL+SHIFT+1"));
+            MyAppend(bordmenu, A_BORD2, _("Border &2\tCTRL+SHIFT+2"));
+            MyAppend(bordmenu, A_BORD3, _("Border &3\tCTRL+SHIFT+3"));
+            MyAppend(bordmenu, A_BORD4, _("Border &4\tCTRL+SHIFT+4"));
+            MyAppend(bordmenu, A_BORD5, _("Border &5\tCTRL+SHIFT+5"));
 
             wxMenu *selmenu = new wxMenu();
             MyAppend(selmenu, A_NEXT,
                 #ifdef __WXGTK__
-                    _(L"Move to next cell (TAB)")
+                    _("Move to next cell (TAB)")
                 #else
-                    _(L"Move to next cell\tTAB")
+                    _("Move to next cell\tTAB")
                 #endif
             );
             MyAppend(selmenu, A_PREV, 
                 #ifdef __WXGTK__
-                    _(L"Move to previous cell (SHIFT+TAB)")
+                    _("Move to previous cell (SHIFT+TAB)")
                 #else
-                    _(L"Move to previous cell\tSHIFT+TAB")
+                    _("Move to previous cell\tSHIFT+TAB")
                 #endif
             );
             selmenu->AppendSeparator();
-            MyAppend(selmenu, wxID_SELECTALL, _(L"Select &all in current grid/cell\tCTRL+a"));
+            MyAppend(selmenu, wxID_SELECTALL, _("Select &all in current grid/cell\tCTRL+a"));
             selmenu->AppendSeparator();
             MyAppend(selmenu, A_LEFT, 
                 #ifdef __WXGTK__
-                    _(L"Move Selection Left (LEFT)")
+                    _("Move Selection Left (LEFT)")
                 #else
-                    _(L"Move Selection Left\tLEFT")
+                    _("Move Selection Left\tLEFT")
                 #endif
             );
             MyAppend(selmenu, A_RIGHT, 
                 #ifdef __WXGTK__
-                    _(L"Move Selection Right (RIGHT)")
+                    _("Move Selection Right (RIGHT)")
                 #else 
-                    _(L"Move Selection Right\tRIGHT")
+                    _("Move Selection Right\tRIGHT")
                 #endif
             );
             MyAppend(selmenu, A_UP, 
                 #ifdef __WXGTK__
-                    _(L"Move Selection Up (UP)")
+                    _("Move Selection Up (UP)")
                 #else
-                    _(L"Move Selection Up\tUP")
+                    _("Move Selection Up\tUP")
                 #endif
             );
             MyAppend(selmenu, A_DOWN, 
                 #ifdef __WXGTK__
-                    _(L"Move Selection Down (DOWN)")
+                    _("Move Selection Down (DOWN)")
                 #else
-                    _(L"Move Selection Down\tDOWN")
+                    _("Move Selection Down\tDOWN")
                 #endif
             );
             selmenu->AppendSeparator();
-            MyAppend(selmenu, A_MLEFT, _(L"Move Cells Left\tCTRL+LEFT"));
-            MyAppend(selmenu, A_MRIGHT, _(L"Move Cells Right\tCTRL+RIGHT"));
-            MyAppend(selmenu, A_MUP, _(L"Move Cells Up\tCTRL+UP"));
-            MyAppend(selmenu, A_MDOWN, _(L"Move Cells Down\tCTRL+DOWN"));
+            MyAppend(selmenu, A_MLEFT, _("Move Cells Left\tCTRL+LEFT"));
+            MyAppend(selmenu, A_MRIGHT, _("Move Cells Right\tCTRL+RIGHT"));
+            MyAppend(selmenu, A_MUP, _("Move Cells Up\tCTRL+UP"));
+            MyAppend(selmenu, A_MDOWN, _("Move Cells Down\tCTRL+DOWN"));
             selmenu->AppendSeparator();
-            MyAppend(selmenu, A_SLEFT, _(L"Extend Selection Left\tSHIFT+LEFT"));
-            MyAppend(selmenu, A_SRIGHT, _(L"Extend Selection Right\tSHIFT+RIGHT"));
-            MyAppend(selmenu, A_SUP, _(L"Extend Selection Up\tSHIFT+UP"));
-            MyAppend(selmenu, A_SDOWN, _(L"Extend Selection Down\tSHIFT+DOWN"));
-            MyAppend(selmenu, A_SCOLS, _(L"Extend Selection Full Columns"));
-            MyAppend(selmenu, A_SROWS, _(L"Extend Selection Full Rows"));
+            MyAppend(selmenu, A_SLEFT, _("Extend Selection Left\tSHIFT+LEFT"));
+            MyAppend(selmenu, A_SRIGHT, _("Extend Selection Right\tSHIFT+RIGHT"));
+            MyAppend(selmenu, A_SUP, _("Extend Selection Up\tSHIFT+UP"));
+            MyAppend(selmenu, A_SDOWN, _("Extend Selection Down\tSHIFT+DOWN"));
+            MyAppend(selmenu, A_SCOLS, _("Extend Selection Full Columns"));
+            MyAppend(selmenu, A_SROWS, _("Extend Selection Full Rows"));
             selmenu->AppendSeparator();
-            MyAppend(selmenu, A_CANCELEDIT, _(L"Select &Parent\tESC"));
-            MyAppend(selmenu, A_ENTERGRID, _(L"Select First &Child\tSHIFT+ENTER"));
+            MyAppend(selmenu, A_CANCELEDIT, _("Select &Parent\tESC"));
+            MyAppend(selmenu, A_ENTERGRID, _("Select First &Child\tSHIFT+ENTER"));
             selmenu->AppendSeparator();
-            MyAppend(selmenu, A_LINK, _(L"Go To &Matching Cell (Text)\tF6"));
-            MyAppend(selmenu, A_LINKREV, _(L"Go To Matching Cell (Text, Reverse)\tSHIFT+F6"));
-            MyAppend(selmenu, A_LINKIMG, _(L"Go To Matching Cell (Image)\tF7"));
-            MyAppend(selmenu, A_LINKIMGREV, _(L"Go To Matching Cell (Image, Reverse)\tSHIFT+F7"));
+            MyAppend(selmenu, A_LINK, _("Go To &Matching Cell (Text)\tF6"));
+            MyAppend(selmenu, A_LINKREV, _("Go To Matching Cell (Text, Reverse)\tSHIFT+F6"));
+            MyAppend(selmenu, A_LINKIMG, _("Go To Matching Cell (Image)\tF7"));
+            MyAppend(selmenu, A_LINKIMGREV, _("Go To Matching Cell (Image, Reverse)\tSHIFT+F7"));
 
             wxMenu *temenu = new wxMenu();
-            MyAppend(temenu, A_LEFT, _(L"Cursor Left\tLEFT"));
-            MyAppend(temenu, A_RIGHT, _(L"Cursor Right\tRIGHT"));
-            MyAppend(temenu, A_MLEFT, _(L"Word Left\tCTRL+LEFT"));
-            MyAppend(temenu, A_MRIGHT, _(L"Word Right\tCTRL+RIGHT"));
+            MyAppend(temenu, A_LEFT, _("Cursor Left\tLEFT"));
+            MyAppend(temenu, A_RIGHT, _("Cursor Right\tRIGHT"));
+            MyAppend(temenu, A_MLEFT, _("Word Left\tCTRL+LEFT"));
+            MyAppend(temenu, A_MRIGHT, _("Word Right\tCTRL+RIGHT"));
             temenu->AppendSeparator();
-            MyAppend(temenu, A_SLEFT, _(L"Extend Selection Left\tSHIFT+LEFT"));
-            MyAppend(temenu, A_SRIGHT, _(L"Extend Selection Right\tSHIFT+RIGHT"));
-            MyAppend(temenu, A_SCLEFT, _(L"Extend Selection Word Left\tCTRL+SHIFT+LEFT"));
-            MyAppend(temenu, A_SCRIGHT, _(L"Extend Selection Word Right\tCTRL+SHIFT+RIGHT"));
-            MyAppend(temenu, A_SHOME, _(L"Extend Selection to Start\tSHIFT+HOME"));
-            MyAppend(temenu, A_SEND, _(L"Extend Selection to End\tSHIFT+END"));
+            MyAppend(temenu, A_SLEFT, _("Extend Selection Left\tSHIFT+LEFT"));
+            MyAppend(temenu, A_SRIGHT, _("Extend Selection Right\tSHIFT+RIGHT"));
+            MyAppend(temenu, A_SCLEFT, _("Extend Selection Word Left\tCTRL+SHIFT+LEFT"));
+            MyAppend(temenu, A_SCRIGHT, _("Extend Selection Word Right\tCTRL+SHIFT+RIGHT"));
+            MyAppend(temenu, A_SHOME, _("Extend Selection to Start\tSHIFT+HOME"));
+            MyAppend(temenu, A_SEND, _("Extend Selection to End\tSHIFT+END"));
             temenu->AppendSeparator();
-            MyAppend(temenu, A_HOME, _(L"Start of line of text\tHOME"));
-            MyAppend(temenu, A_END, _(L"End of line of text\tEND"));
-            MyAppend(temenu, A_CHOME, _(L"Start of text\tCTRL+HOME"));
-            MyAppend(temenu, A_CEND, _(L"End of text\tCTRL+END"));
+            MyAppend(temenu, A_HOME, _("Start of line of text\tHOME"));
+            MyAppend(temenu, A_END, _("End of line of text\tEND"));
+            MyAppend(temenu, A_CHOME, _("Start of text\tCTRL+HOME"));
+            MyAppend(temenu, A_CEND, _("End of text\tCTRL+END"));
             temenu->AppendSeparator();
-            MyAppend(temenu, A_ENTERCELL, _(L"Enter/exit text edit mode\tENTER"));
-            MyAppend(temenu, A_ENTERCELL_JUMPTOEND, _(L"Enter/exit text edit mode\tF2"));
-            MyAppend(temenu, A_PROGRESSCELL, _(L"Enter/exit text edit to the right\tALT+ENTER"));
-            MyAppend(temenu, A_CANCELEDIT, _(L"Cancel text edits\tESC"));
+            MyAppend(temenu, A_ENTERCELL, _("Enter/exit text edit mode\tENTER"));
+            MyAppend(temenu, A_ENTERCELL_JUMPTOEND, _("Enter/exit text edit mode\tF2"));
+            MyAppend(temenu, A_PROGRESSCELL, _("Enter/exit text edit to the right\tALT+ENTER"));
+            MyAppend(temenu, A_CANCELEDIT, _("Cancel text edits\tESC"));
 
             wxMenu *stmenu = new wxMenu();
-            MyAppend(stmenu, wxID_BOLD, _(L"Toggle cell &BOLD\tCTRL+b"));
-            MyAppend(stmenu, wxID_ITALIC, _(L"Toggle cell &ITALIC\tCTRL+i"));
-            MyAppend(stmenu, A_TT, _(L"Toggle cell &typewriter\tCTRL+ALT+t"));
-            MyAppend(stmenu, wxID_UNDERLINE, _(L"Toggle cell &underlined\tCTRL+u"));
-            MyAppend(stmenu, wxID_STRIKETHROUGH, _(L"Toggle cell &strikethrough\tCTRL+t"));
+            MyAppend(stmenu, wxID_BOLD, _("Toggle cell &BOLD\tCTRL+b"));
+            MyAppend(stmenu, wxID_ITALIC, _("Toggle cell &ITALIC\tCTRL+i"));
+            MyAppend(stmenu, A_TT, _("Toggle cell &typewriter\tCTRL+ALT+t"));
+            MyAppend(stmenu, wxID_UNDERLINE, _("Toggle cell &underlined\tCTRL+u"));
+            MyAppend(stmenu, wxID_STRIKETHROUGH, _("Toggle cell &strikethrough\tCTRL+t"));
             stmenu->AppendSeparator();
-            MyAppend(stmenu, A_RESETSTYLE, _(L"&Reset text styles\tCTRL+SHIFT+r"));
-            MyAppend(stmenu, A_RESETCOLOR, _(L"Reset &colors\tCTRL+SHIFT+c"));
+            MyAppend(stmenu, A_RESETSTYLE, _("&Reset text styles\tCTRL+SHIFT+r"));
+            MyAppend(stmenu, A_RESETCOLOR, _("Reset &colors\tCTRL+SHIFT+c"));
             stmenu->AppendSeparator();
-            MyAppend(stmenu, A_LASTCELLCOLOR, _(L"Apply last cell color\tSHIFT+ALT+c"));
-            MyAppend(stmenu, A_LASTTEXTCOLOR, _(L"Apply last text color\tSHIFT+ALT+t"));
-            MyAppend(stmenu, A_LASTBORDCOLOR, _(L"Apply last border color\tSHIFT+ALT+b"));
-            MyAppend(stmenu, A_OPENCELLCOLOR, _(L"Open cell colors\tSHIFT+ALT+F9"));
-            MyAppend(stmenu, A_OPENTEXTCOLOR, _(L"Open text colors\tSHIFT+ALT+F10"));
-            MyAppend(stmenu, A_OPENBORDCOLOR, _(L"Open border colors\tSHIFT+ALT+F11"));
+            MyAppend(stmenu, A_LASTCELLCOLOR, _("Apply last cell color\tSHIFT+ALT+c"));
+            MyAppend(stmenu, A_LASTTEXTCOLOR, _("Apply last text color\tSHIFT+ALT+t"));
+            MyAppend(stmenu, A_LASTBORDCOLOR, _("Apply last border color\tSHIFT+ALT+b"));
+            MyAppend(stmenu, A_OPENCELLCOLOR, _("Open cell colors\tSHIFT+ALT+F9"));
+            MyAppend(stmenu, A_OPENTEXTCOLOR, _("Open text colors\tSHIFT+ALT+F10"));
+            MyAppend(stmenu, A_OPENBORDCOLOR, _("Open border colors\tSHIFT+ALT+F11"));
 
             wxMenu *tagmenu = new wxMenu();
-            MyAppend(tagmenu, A_TAGADD, _(L"&Add Cell Text as Tag"));
-            MyAppend(tagmenu, A_TAGREMOVE, _(L"&Remove Cell Text from Tags"));
-            MyAppend(tagmenu, A_NOP, _(L"&Set Cell Text to tag (use CTRL+RMB)"),
-                     _(L"Hold CTRL while pressing right mouse button to quickly set a tag for the current cell using a popup menu"));
+            MyAppend(tagmenu, A_TAGADD, _("&Add Cell Text as Tag"));
+            MyAppend(tagmenu, A_TAGREMOVE, _("&Remove Cell Text from Tags"));
+            MyAppend(tagmenu, A_NOP, _("&Set Cell Text to tag (use CTRL+RMB)"),
+                     _("Hold CTRL while pressing right mouse button to quickly set a tag for the current cell using a popup menu"));
 
             wxMenu *orgmenu = new wxMenu();
-            MyAppend(orgmenu, A_TRANSPOSE, _(L"&Transpose\tCTRL+SHIFT+t"),
-                     _(L"changes the orientation of a grid"));
-            MyAppend(orgmenu, A_SORT, _(L"Sort &Ascending"),
-                     _(L"Make a 1xN selection to indicate which column to sort on, and which rows to affect"));
-            MyAppend(orgmenu, A_SORTD, _(L"Sort &Descending"),
-                     _(L"Make a 1xN selection to indicate which column to sort on, and which rows to affect"));
-            MyAppend(orgmenu, A_HSWAP, _(L"Hierarchy &Swap\tF8"),
-                     _(L"Swap all cells with this text at this level (or above) with the parent"));
-            MyAppend(orgmenu, A_HIFY, _(L"&Hierarchify"),
-                     _(L"Convert an NxN grid with repeating elements per column into an 1xN grid with hierarchy, useful to convert data from spreadsheets"));
-            MyAppend(orgmenu, A_FLATTEN, _(L"&Flatten"),
-                     _(L"Takes a hierarchy (nested 1xN or Nx1 grids) and converts it into a flat NxN grid, useful for export to spreadsheets"));
+            MyAppend(orgmenu, A_TRANSPOSE, _("&Transpose\tCTRL+SHIFT+t"),
+                     _("changes the orientation of a grid"));
+            MyAppend(orgmenu, A_SORT, _("Sort &Ascending"),
+                     _("Make a 1xN selection to indicate which column to sort on, and which rows to affect"));
+            MyAppend(orgmenu, A_SORTD, _("Sort &Descending"),
+                     _("Make a 1xN selection to indicate which column to sort on, and which rows to affect"));
+            MyAppend(orgmenu, A_HSWAP, _("Hierarchy &Swap\tF8"),
+                     _("Swap all cells with this text at this level (or above) with the parent"));
+            MyAppend(orgmenu, A_HIFY, _("&Hierarchify"),
+                     _("Convert an NxN grid with repeating elements per column into an 1xN grid with hierarchy, useful to convert data from spreadsheets"));
+            MyAppend(orgmenu, A_FLATTEN, _("&Flatten"),
+                     _("Takes a hierarchy (nested 1xN or Nx1 grids) and converts it into a flat NxN grid, useful for export to spreadsheets"));
 
             wxMenu *imgmenu = new wxMenu();
-            MyAppend(imgmenu, A_IMAGE, _(L"&Add Image"), _(L"Adds an image to the selected cell"));
-            MyAppend(imgmenu, A_IMAGESVA, _(L"Save Image(s) to disk"),
-                     _(L"Save image(s) to disk. Multiple images will be saved with a counter appended to each file name."));
+            MyAppend(imgmenu, A_IMAGE, _("&Add Image"), _("Adds an image to the selected cell"));
+            MyAppend(imgmenu, A_IMAGESVA, _("Save Image(s) to disk"),
+                     _("Save image(s) to disk. Multiple images will be saved with a counter appended to each file name."));
             imgmenu->AppendSeparator();
             MyAppend(
-                imgmenu, A_IMAGESCP, _(L"&Scale Image (re-sample pixels, by %)"),
-                _(L"Change the image size if it is too big, by reducing the amount of pixels"));
+                imgmenu, A_IMAGESCP, _("&Scale Image (re-sample pixels, by %)"),
+                _("Change the image size if it is too big, by reducing the amount of pixels"));
             MyAppend(
-                imgmenu, A_IMAGESCW, _(L"&Scale Image (re-sample pixels, by width)"),
-                _(L"Change the image size if it is too big, by reducing the amount of pixels"));
-            MyAppend(imgmenu, A_IMAGESCF, _(L"&Scale Image (display only)"),
-                     _(L"Change the image size if it is too big or too small, by changing the size shown on screen. Applies to all uses of this image."));
-            MyAppend(imgmenu, A_IMAGESCN, _(L"&Reset Scale (display only)"),
-                     _(L"Change the scale to match DPI of the current display. Applies to all uses of this image."));
+                imgmenu, A_IMAGESCW, _("&Scale Image (re-sample pixels, by width)"),
+                _("Change the image size if it is too big, by reducing the amount of pixels"));
+            MyAppend(imgmenu, A_IMAGESCF, _("&Scale Image (display only)"),
+                     _("Change the image size if it is too big or too small, by changing the size shown on screen. Applies to all uses of this image."));
+            MyAppend(imgmenu, A_IMAGESCN, _("&Reset Scale (display only)"),
+                     _("Change the scale to match DPI of the current display. Applies to all uses of this image."));
             imgmenu->AppendSeparator();
-            MyAppend(imgmenu, A_SAVE_AS_JPEG, _(L"Save image as JPEG"),
-                     _(L"Save the image in the TreeSheets file in JPEG format"));
-            MyAppend(imgmenu, A_SAVE_AS_PNG, _(L"Save image as PNG (default)"),
-                     _(L"Save the image in the TreeSheets file in PNG format"));
+            MyAppend(imgmenu, A_SAVE_AS_JPEG, _("Save image as JPEG"),
+                     _("Save the image in the TreeSheets file in JPEG format"));
+            MyAppend(imgmenu, A_SAVE_AS_PNG, _("Save image as PNG (default)"),
+                     _("Save the image in the TreeSheets file in PNG format"));
             imgmenu->AppendSeparator();
-            MyAppend(imgmenu, A_IMAGER, _(L"&Remove Image(s)"),
-                     _(L"Remove image(s) from the selected cells"));
+            MyAppend(imgmenu, A_IMAGER, _("&Remove Image(s)"),
+                     _("Remove image(s) from the selected cells"));
 
             wxMenu *navmenu = new wxMenu();
-            MyAppend(navmenu, A_BROWSE, _(L"Open link in &browser\tF5"),
-                     _(L"Opens up the text from the selected cell in browser (should start be a valid URL)"));
-            MyAppend(navmenu, A_BROWSEF, _(L"Open &file\tF4"),
-                     _(L"Opens up the text from the selected cell in default application for the file type"));
+            MyAppend(navmenu, A_BROWSE, _("Open link in &browser\tF5"),
+                     _("Opens up the text from the selected cell in browser (should start be a valid URL)"));
+            MyAppend(navmenu, A_BROWSEF, _("Open &file\tF4"),
+                     _("Opens up the text from the selected cell in default application for the file type"));
 
             #ifdef __WXMAC__
                 #define CTRLORALT "CTRL"
@@ -394,215 +394,215 @@ struct MyFrame : wxFrame {
 
             wxMenu *laymenu = new wxMenu();
             MyAppend(laymenu, A_V_GS,
-                     _(L"Vertical Layout with Grid Style Rendering\t" CTRLORALT "+1"));
+                     _("Vertical Layout with Grid Style Rendering\t" CTRLORALT "+1"));
             MyAppend(laymenu, A_V_BS,
-                     _(L"Vertical Layout with Bubble Style Rendering\t" CTRLORALT "+2"));
+                     _("Vertical Layout with Bubble Style Rendering\t" CTRLORALT "+2"));
             MyAppend(laymenu, A_V_LS,
-                     _(L"Vertical Layout with Line Style Rendering\t" CTRLORALT "+3"));
+                     _("Vertical Layout with Line Style Rendering\t" CTRLORALT "+3"));
             laymenu->AppendSeparator();
             MyAppend(laymenu, A_H_GS,
-                     _(L"Horizontal Layout with Grid Style Rendering\t" CTRLORALT "+4"));
+                     _("Horizontal Layout with Grid Style Rendering\t" CTRLORALT "+4"));
             MyAppend(laymenu, A_H_BS,
-                     _(L"Horizontal Layout with Bubble Style Rendering\t" CTRLORALT "+5"));
+                     _("Horizontal Layout with Bubble Style Rendering\t" CTRLORALT "+5"));
             MyAppend(laymenu, A_H_LS,
-                     _(L"Horizontal Layout with Line Style Rendering\t" CTRLORALT "+6"));
+                     _("Horizontal Layout with Line Style Rendering\t" CTRLORALT "+6"));
             laymenu->AppendSeparator();
-            MyAppend(laymenu, A_GS, _(L"Grid Style Rendering\t" CTRLORALT "+7"));
-            MyAppend(laymenu, A_BS, _(L"Bubble Style Rendering\t" CTRLORALT "+8"));
-            MyAppend(laymenu, A_LS, _(L"Line Style Rendering\t" CTRLORALT "+9"));
+            MyAppend(laymenu, A_GS, _("Grid Style Rendering\t" CTRLORALT "+7"));
+            MyAppend(laymenu, A_BS, _("Bubble Style Rendering\t" CTRLORALT "+8"));
+            MyAppend(laymenu, A_LS, _("Line Style Rendering\t" CTRLORALT "+9"));
             laymenu->AppendSeparator();
-            MyAppend(laymenu, A_TEXTGRID, _(L"Toggle Vertical Layout\t" CTRLORALT "+0"),
-                     _(L"Make a hierarchy layout more vertical (default) or more horizontal"));
+            MyAppend(laymenu, A_TEXTGRID, _("Toggle Vertical Layout\t" CTRLORALT "+0"),
+                     _("Make a hierarchy layout more vertical (default) or more horizontal"));
 
             editmenu = new wxMenu();
-            MyAppend(editmenu, wxID_CUT, _(L"Cu&t\tCTRL+x"));
-            MyAppend(editmenu, wxID_COPY, _(L"&Copy\tCTRL+c"));
+            MyAppend(editmenu, wxID_CUT, _("Cu&t\tCTRL+x"));
+            MyAppend(editmenu, wxID_COPY, _("&Copy\tCTRL+c"));
             editmenu->AppendSeparator();
-            MyAppend(editmenu, A_COPYWI, _(L"Copy with &Images\tCTRL+ALT+c"));
-            MyAppend(editmenu, A_COPYBM, _(L"&Copy as Bitmap"));
-            MyAppend(editmenu, A_COPYCT, _(L"Copy As Continuous Text"));
+            MyAppend(editmenu, A_COPYWI, _("Copy with &Images\tCTRL+ALT+c"));
+            MyAppend(editmenu, A_COPYBM, _("&Copy as Bitmap"));
+            MyAppend(editmenu, A_COPYCT, _("Copy As Continuous Text"));
             editmenu->AppendSeparator();
-            MyAppend(editmenu, wxID_PASTE, _(L"&Paste\tCTRL+v"));
-            MyAppend(editmenu, A_PASTESTYLE, _(L"Paste Style Only\tCTRL+SHIFT+v"),
-                     _(L"only sets the colors and style of the copied cell, and keeps the text"));
-            MyAppend(editmenu, A_COLLAPSE, _(L"Collapse Ce&lls\tCTRL+l"));
+            MyAppend(editmenu, wxID_PASTE, _("&Paste\tCTRL+v"));
+            MyAppend(editmenu, A_PASTESTYLE, _("Paste Style Only\tCTRL+SHIFT+v"),
+                     _("only sets the colors and style of the copied cell, and keeps the text"));
+            MyAppend(editmenu, A_COLLAPSE, _("Collapse Ce&lls\tCTRL+l"));
             editmenu->AppendSeparator();
-            MyAppend(editmenu, wxID_UNDO, _(L"&Undo\tCTRL+z"),
-                     _(L"revert the changes, one step at a time"));
-            MyAppend(editmenu, wxID_REDO, _(L"&Redo\tCTRL+y"),
-                     _(L"redo any undo steps, if you haven't made changes since"));
+            MyAppend(editmenu, wxID_UNDO, _("&Undo\tCTRL+z"),
+                     _("revert the changes, one step at a time"));
+            MyAppend(editmenu, wxID_REDO, _("&Redo\tCTRL+y"),
+                     _("redo any undo steps, if you haven't made changes since"));
             editmenu->AppendSeparator();
             MyAppend(
-                editmenu, A_DELETE, _(L"&Delete After\tDEL"),
-                _(L"Deletes the column of cells after the selected grid line, or the row below"));
+                editmenu, A_DELETE, _("&Delete After\tDEL"),
+                _("Deletes the column of cells after the selected grid line, or the row below"));
             MyAppend(
-                editmenu, A_BACKSPACE, _(L"Delete Before\tBACK"),
-                _(L"Deletes the column of cells before the selected grid line, or the row above"));
-            MyAppend(editmenu, A_DELETE_WORD, _(L"Delete Word After\tCTRL+DEL"),
-                     _(L"Deletes the entire word after the cursor"));
-            MyAppend(editmenu, A_BACKSPACE_WORD, _(L"Delete Word Before\tCTRL+BACK"),
-                     _(L"Deletes the entire word before the cursor"));
+                editmenu, A_BACKSPACE, _("Delete Before\tBACK"),
+                _("Deletes the column of cells before the selected grid line, or the row above"));
+            MyAppend(editmenu, A_DELETE_WORD, _("Delete Word After\tCTRL+DEL"),
+                     _("Deletes the entire word after the cursor"));
+            MyAppend(editmenu, A_BACKSPACE_WORD, _("Delete Word Before\tCTRL+BACK"),
+                     _("Deletes the entire word before the cursor"));
             editmenu->AppendSeparator();
             MyAppend(editmenu, A_NEWGRID,
                      #ifdef __WXMAC__
-                     _(L"&Insert New Grid\tCTRL+g"),
+                     _("&Insert New Grid\tCTRL+g"),
                      #else
-                     _(L"&Insert New Grid\tINS"),
+                     _("&Insert New Grid\tINS"),
                      #endif
-                     _(L"Adds a grid to the selected cell"));
-            MyAppend(editmenu, A_WRAP, _(L"&Wrap in new parent\tF9"),
-                     _(L"Creates a new level of hierarchy around the current selection"));
+                     _("Adds a grid to the selected cell"));
+            MyAppend(editmenu, A_WRAP, _("&Wrap in new parent\tF9"),
+                     _("Creates a new level of hierarchy around the current selection"));
             editmenu->AppendSeparator();
             // F10 is tied to the OS on both Ubuntu and OS X, and SHIFT+F10 is now right
             // click on all platforms?
             MyAppend(editmenu, A_FOLD,
                      #ifndef WIN32
-                     _(L"Toggle Fold\tCTRL+F10"),
+                     _("Toggle Fold\tCTRL+F10"),
                      #else
-                     _(L"Toggle Fold\tF10"),
+                     _("Toggle Fold\tF10"),
                      #endif
                     _("Toggles showing the grid of the selected cell(s)"));
-            MyAppend(editmenu, A_FOLDALL, _(L"Fold All\tCTRL+SHIFT+F10"),
-                _(L"Folds the grid of the selected cell(s) recursively"));
-            MyAppend(editmenu, A_UNFOLDALL, _(L"Unfold All\tCTRL+ALT+F10"),
-                _(L"Unfolds the grid of the selected cell(s) recursively"));
+            MyAppend(editmenu, A_FOLDALL, _("Fold All\tCTRL+SHIFT+F10"),
+                _("Folds the grid of the selected cell(s) recursively"));
+            MyAppend(editmenu, A_UNFOLDALL, _("Unfold All\tCTRL+ALT+F10"),
+                _("Unfolds the grid of the selected cell(s) recursively"));
             editmenu->AppendSeparator();
-            editmenu->AppendSubMenu(selmenu, _(L"&Selection..."));
-            editmenu->AppendSubMenu(orgmenu, _(L"&Grid Reorganization..."));
-            editmenu->AppendSubMenu(laymenu, _(L"&Layout && Render Style..."));
-            editmenu->AppendSubMenu(imgmenu, _(L"&Images..."));
-            editmenu->AppendSubMenu(navmenu, _(L"&Browsing..."));
-            editmenu->AppendSubMenu(temenu, _(L"Text &Editing..."));
-            editmenu->AppendSubMenu(sizemenu, _(L"Text Sizing..."));
-            editmenu->AppendSubMenu(stmenu, _(L"Text Style..."));
-            editmenu->AppendSubMenu(bordmenu, _(L"Set Grid Border Width..."));
-            editmenu->AppendSubMenu(tagmenu, _(L"Tag..."));
+            editmenu->AppendSubMenu(selmenu, _("&Selection..."));
+            editmenu->AppendSubMenu(orgmenu, _("&Grid Reorganization..."));
+            editmenu->AppendSubMenu(laymenu, _("&Layout && Render Style..."));
+            editmenu->AppendSubMenu(imgmenu, _("&Images..."));
+            editmenu->AppendSubMenu(navmenu, _("&Browsing..."));
+            editmenu->AppendSubMenu(temenu, _("Text &Editing..."));
+            editmenu->AppendSubMenu(sizemenu, _("Text Sizing..."));
+            editmenu->AppendSubMenu(stmenu, _("Text Style..."));
+            editmenu->AppendSubMenu(bordmenu, _("Set Grid Border Width..."));
+            editmenu->AppendSubMenu(tagmenu, _("Tag..."));
 
             if (!twoeditmenus) editmenupopup = editmenu;
         }
 
         wxMenu *semenu = new wxMenu();
-        MyAppend(semenu, wxID_FIND, _(L"&Search\tCTRL+f"));
-        semenu->AppendCheckItem(A_CASESENSITIVESEARCH, _(L"Case-sensitive search"));
+        MyAppend(semenu, wxID_FIND, _("&Search\tCTRL+f"));
+        semenu->AppendCheckItem(A_CASESENSITIVESEARCH, _("Case-sensitive search"));
         semenu->Check(A_CASESENSITIVESEARCH, sys->casesensitivesearch);
-        MyAppend(semenu, A_SEARCHNEXT, _(L"&Go To Next Search Result\tF3"));
-        MyAppend(semenu, A_SEARCHPREV, _(L"Go To &Previous Search Result\tSHIFT+F3"));
-        MyAppend(semenu, wxID_REPLACE, _(L"&Replace\tCTRL+h"));
-        MyAppend(semenu, A_REPLACEONCE, _(L"Replace in Current &Selection\tCTRL+k"));
-        MyAppend(semenu, A_REPLACEONCEJ, _(L"Replace in Current Selection && &Jump Next\tCTRL+j"));
-        MyAppend(semenu, A_REPLACEALL, _(L"Replace &All"));
+        MyAppend(semenu, A_SEARCHNEXT, _("&Go To Next Search Result\tF3"));
+        MyAppend(semenu, A_SEARCHPREV, _("Go To &Previous Search Result\tSHIFT+F3"));
+        MyAppend(semenu, wxID_REPLACE, _("&Replace\tCTRL+h"));
+        MyAppend(semenu, A_REPLACEONCE, _("Replace in Current &Selection\tCTRL+k"));
+        MyAppend(semenu, A_REPLACEONCEJ, _("Replace in Current Selection && &Jump Next\tCTRL+j"));
+        MyAppend(semenu, A_REPLACEALL, _("Replace &All"));
 
         wxMenu *scrollmenu = new wxMenu();
-        MyAppend(scrollmenu, A_AUP, _(L"Scroll Up (mousewheel)\tPGUP"));
-        MyAppend(scrollmenu, A_AUP, _(L"Scroll Up (mousewheel)\tALT+UP"));
-        MyAppend(scrollmenu, A_ADOWN, _(L"Scroll Down (mousewheel)\tPGDN"));
-        MyAppend(scrollmenu, A_ADOWN, _(L"Scroll Down (mousewheel)\tALT+DOWN"));
-        MyAppend(scrollmenu, A_ALEFT, _(L"Scroll Left\tALT+LEFT"));
-        MyAppend(scrollmenu, A_ARIGHT, _(L"Scroll Right\tALT+RIGHT"));
+        MyAppend(scrollmenu, A_AUP, _("Scroll Up (mousewheel)\tPGUP"));
+        MyAppend(scrollmenu, A_AUP, _("Scroll Up (mousewheel)\tALT+UP"));
+        MyAppend(scrollmenu, A_ADOWN, _("Scroll Down (mousewheel)\tPGDN"));
+        MyAppend(scrollmenu, A_ADOWN, _("Scroll Down (mousewheel)\tALT+DOWN"));
+        MyAppend(scrollmenu, A_ALEFT, _("Scroll Left\tALT+LEFT"));
+        MyAppend(scrollmenu, A_ARIGHT, _("Scroll Right\tALT+RIGHT"));
 
         wxMenu *filtermenu = new wxMenu();
-        MyAppend(filtermenu, A_FILTEROFF, _(L"Turn filter &off"));
-        MyAppend(filtermenu, A_FILTERS, _(L"Show only cells in current search"));
-        MyAppend(filtermenu, A_FILTERRANGE, _(L"Show last edits in specific date range"));
+        MyAppend(filtermenu, A_FILTEROFF, _("Turn filter &off"));
+        MyAppend(filtermenu, A_FILTERS, _("Show only cells in current search"));
+        MyAppend(filtermenu, A_FILTERRANGE, _("Show last edits in specific date range"));
         // xgettext:no-c-format
-        MyAppend(filtermenu, A_FILTER5, _(L"Show 5% of last edits"));
+        MyAppend(filtermenu, A_FILTER5, _("Show 5% of last edits"));
         // xgettext:no-c-format
-        MyAppend(filtermenu, A_FILTER10, _(L"Show 10% of last edits"));
+        MyAppend(filtermenu, A_FILTER10, _("Show 10% of last edits"));
         // xgettext:no-c-format
-        MyAppend(filtermenu, A_FILTER20, _(L"Show 20% of last edits"));
+        MyAppend(filtermenu, A_FILTER20, _("Show 20% of last edits"));
         // xgettext:no-c-format
-        MyAppend(filtermenu, A_FILTER50, _(L"Show 50% of last edits"));
+        MyAppend(filtermenu, A_FILTER50, _("Show 50% of last edits"));
         // xgettext:no-c-format
-        MyAppend(filtermenu, A_FILTERM, _(L"Show 1% more than the last filter"));
+        MyAppend(filtermenu, A_FILTERM, _("Show 1% more than the last filter"));
         // xgettext:no-c-format
-        MyAppend(filtermenu, A_FILTERL, _(L"Show 1% less than the last filter"));
-        MyAppend(filtermenu, A_FILTERBYCELLBG, _(L"Filter by the same cell color"));
-        MyAppend(filtermenu, A_FILTERMATCHNEXT, _(L"Go to next filter match\tCTRL+F3"));
+        MyAppend(filtermenu, A_FILTERL, _("Show 1% less than the last filter"));
+        MyAppend(filtermenu, A_FILTERBYCELLBG, _("Filter by the same cell color"));
+        MyAppend(filtermenu, A_FILTERMATCHNEXT, _("Go to next filter match\tCTRL+F3"));
 
         wxMenu *viewmenu = new wxMenu();
-        MyAppend(viewmenu, A_ZOOMIN, _(L"Zoom &In (CTRL+mousewheel)\tCTRL+PGUP"));
-        MyAppend(viewmenu, A_ZOOMOUT, _(L"Zoom &Out (CTRL+mousewheel)\tCTRL+PGDN"));
+        MyAppend(viewmenu, A_ZOOMIN, _("Zoom &In (CTRL+mousewheel)\tCTRL+PGUP"));
+        MyAppend(viewmenu, A_ZOOMOUT, _("Zoom &Out (CTRL+mousewheel)\tCTRL+PGDN"));
         MyAppend(viewmenu, A_NEXTFILE,
                  #ifndef __WXGTK__
-                 _(L"Switch to &next file/tab\tCTRL+TAB"));
+                 _("Switch to &next file/tab\tCTRL+TAB"));
                  #else
                  // On Linux, this conflicts with CTRL+I, see Document::Key()
                  // CTRL+SHIFT+TAB below still works, so that will have to be used to switch tabs.
-                 _(L"Switch to &next file/tab"));
+                 _("Switch to &next file/tab"));
                  #endif
-        MyAppend(viewmenu, A_PREVFILE, _(L"Switch to &previous file/tab\tCTRL+SHIFT+TAB"));
+        MyAppend(viewmenu, A_PREVFILE, _("Switch to &previous file/tab\tCTRL+SHIFT+TAB"));
         MyAppend(viewmenu, A_FULLSCREEN,
                  #ifdef __WXMAC__
-                 _(L"Toggle &Fullscreen View\tCTRL+F11"));
+                 _("Toggle &Fullscreen View\tCTRL+F11"));
                  #else
-                 _(L"Toggle &Fullscreen View\tF11"));
+                 _("Toggle &Fullscreen View\tF11"));
                  #endif
         MyAppend(viewmenu, A_SCALED,
                  #ifdef __WXMAC__
-                 _(L"Toggle &Scaled Presentation View\tCTRL+F12"));
+                 _("Toggle &Scaled Presentation View\tCTRL+F12"));
                  #else
-                 _(L"Toggle &Scaled Presentation View\tF12"));
+                 _("Toggle &Scaled Presentation View\tF12"));
                  #endif
-        viewmenu->AppendSubMenu(scrollmenu, _(L"Scroll Sheet..."));
-        viewmenu->AppendSubMenu(filtermenu, _(L"Filter..."));
-        MyAppend(viewmenu, A_SHOWSTATS, _(L"Show statistics\tCTRL+d"));
+        viewmenu->AppendSubMenu(scrollmenu, _("Scroll Sheet..."));
+        viewmenu->AppendSubMenu(filtermenu, _("Filter..."));
+        MyAppend(viewmenu, A_SHOWSTATS, _("Show statistics\tCTRL+d"));
 
         wxMenu *roundmenu = new wxMenu();
-        roundmenu->AppendRadioItem(A_ROUND0, _(L"Radius &0"));
-        roundmenu->AppendRadioItem(A_ROUND1, _(L"Radius &1"));
-        roundmenu->AppendRadioItem(A_ROUND2, _(L"Radius &2"));
-        roundmenu->AppendRadioItem(A_ROUND3, _(L"Radius &3"));
-        roundmenu->AppendRadioItem(A_ROUND4, _(L"Radius &4"));
-        roundmenu->AppendRadioItem(A_ROUND5, _(L"Radius &5"));
-        roundmenu->AppendRadioItem(A_ROUND6, _(L"Radius &6"));
+        roundmenu->AppendRadioItem(A_ROUND0, _("Radius &0"));
+        roundmenu->AppendRadioItem(A_ROUND1, _("Radius &1"));
+        roundmenu->AppendRadioItem(A_ROUND2, _("Radius &2"));
+        roundmenu->AppendRadioItem(A_ROUND3, _("Radius &3"));
+        roundmenu->AppendRadioItem(A_ROUND4, _("Radius &4"));
+        roundmenu->AppendRadioItem(A_ROUND5, _("Radius &5"));
+        roundmenu->AppendRadioItem(A_ROUND6, _("Radius &6"));
         roundmenu->Check(sys->roundness + A_ROUND0, true);
 
         wxMenu *optmenu = new wxMenu();
-        MyAppend(optmenu, wxID_SELECT_FONT, _(L"Pick Default Font..."));
-        MyAppend(optmenu, A_CUSTKEY, _(L"Change a key binding..."));
-        MyAppend(optmenu, A_CUSTCOL, _(L"Pick Custom &Color..."));
-        MyAppend(optmenu, A_COLCELL, _(L"&Set Custom Color From Cell BG"));
-        MyAppend(optmenu, A_DEFBGCOL, _(L"Pick Document Background..."));
+        MyAppend(optmenu, wxID_SELECT_FONT, _("Pick Default Font..."));
+        MyAppend(optmenu, A_CUSTKEY, _("Change a key binding..."));
+        MyAppend(optmenu, A_CUSTCOL, _("Pick Custom &Color..."));
+        MyAppend(optmenu, A_COLCELL, _("&Set Custom Color From Cell BG"));
+        MyAppend(optmenu, A_DEFBGCOL, _("Pick Document Background..."));
         #ifdef SIMPLERENDER
-            MyAppend(optmenu, A_DEFCURCOL, _(L"Pick Cu&rsor Color..."));
+            MyAppend(optmenu, A_DEFCURCOL, _("Pick Cu&rsor Color..."));
         #else
-            optmenu->AppendCheckItem(A_HOVERSHADOW, _(L"Hover shadow"));
+            optmenu->AppendCheckItem(A_HOVERSHADOW, _("Hover shadow"));
             optmenu->Check(A_HOVERSHADOW, sys->hovershadow);
         #endif
         optmenu->AppendSeparator();
-        optmenu->AppendCheckItem(A_SHOWTBAR, _(L"Show Toolbar"));
+        optmenu->AppendCheckItem(A_SHOWTBAR, _("Show Toolbar"));
         optmenu->Check(A_SHOWTBAR, sys->showtoolbar);
-        optmenu->AppendCheckItem(A_SHOWSBAR, _(L"Show Statusbar"));
+        optmenu->AppendCheckItem(A_SHOWSBAR, _("Show Statusbar"));
         optmenu->Check(A_SHOWSBAR, sys->showstatusbar);
-        optmenu->AppendCheckItem(A_LEFTTABS, _(L"File Tabs on the bottom"));
+        optmenu->AppendCheckItem(A_LEFTTABS, _("File Tabs on the bottom"));
         optmenu->Check(A_LEFTTABS, lefttabs);
-        optmenu->AppendCheckItem(A_TOTRAY, _(L"Minimize to tray"));
+        optmenu->AppendCheckItem(A_TOTRAY, _("Minimize to tray"));
         optmenu->Check(A_TOTRAY, sys->totray);
-        optmenu->AppendCheckItem(A_MINCLOSE, _(L"Minimize on close"));
+        optmenu->AppendCheckItem(A_MINCLOSE, _("Minimize on close"));
         optmenu->Check(A_MINCLOSE, sys->minclose);
-        optmenu->AppendCheckItem(A_SINGLETRAY, _(L"Single click maximize from tray"));
+        optmenu->AppendCheckItem(A_SINGLETRAY, _("Single click maximize from tray"));
         optmenu->Check(A_SINGLETRAY, sys->singletray);
         optmenu->AppendSeparator();
-        optmenu->AppendCheckItem(A_ZOOMSCR, _(L"Swap mousewheel scrolling and zooming"));
+        optmenu->AppendCheckItem(A_ZOOMSCR, _("Swap mousewheel scrolling and zooming"));
         optmenu->Check(A_ZOOMSCR, sys->zoomscroll);
-        optmenu->AppendCheckItem(A_THINSELC, _(L"Navigate in between cells with cursor keys"));
+        optmenu->AppendCheckItem(A_THINSELC, _("Navigate in between cells with cursor keys"));
         optmenu->Check(A_THINSELC, sys->thinselc);
         optmenu->AppendSeparator();
-        optmenu->AppendCheckItem(A_MAKEBAKS, _(L"Create .bak files"));
+        optmenu->AppendCheckItem(A_MAKEBAKS, _("Create .bak files"));
         optmenu->Check(A_MAKEBAKS, sys->makebaks);
-        optmenu->AppendCheckItem(A_AUTOSAVE, _(L"Autosave to .tmp"));
+        optmenu->AppendCheckItem(A_AUTOSAVE, _("Autosave to .tmp"));
         optmenu->Check(A_AUTOSAVE, sys->autosave);
-        optmenu->AppendCheckItem(A_FSWATCH, _(L"Auto reload documents"),
-                                 _(L"Reloads when another computer has changed a file (if you have made changes, asks)"));
+        optmenu->AppendCheckItem(A_FSWATCH, _("Auto reload documents"),
+                                 _("Reloads when another computer has changed a file (if you have made changes, asks)"));
         optmenu->Check(A_FSWATCH, sys->fswatch);
-        optmenu->AppendCheckItem(A_AUTOEXPORT, _(L"Automatically export a .html on every save"));
+        optmenu->AppendCheckItem(A_AUTOEXPORT, _("Automatically export a .html on every save"));
         optmenu->Check(A_AUTOEXPORT, sys->autohtmlexport);
         optmenu->AppendSeparator();
-        optmenu->AppendCheckItem(A_CENTERED, _(L"Render document centered"));
+        optmenu->AppendCheckItem(A_CENTERED, _("Render document centered"));
         optmenu->Check(A_CENTERED, sys->centered);
-        optmenu->AppendCheckItem(A_FASTRENDER, _(L"Faster line rendering"));
+        optmenu->AppendCheckItem(A_FASTRENDER, _("Faster line rendering"));
         optmenu->Check(A_FASTRENDER, sys->fastrender);
-        optmenu->AppendSubMenu(roundmenu, _(L"&Roundness of grid borders..."));
+        optmenu->AppendSubMenu(roundmenu, _("&Roundness of grid borders..."));
 
         wxMenu *scriptmenu = new wxMenu();
         auto scriptpath = GetDataPath("scripts/");
@@ -623,23 +623,23 @@ struct MyFrame : wxFrame {
         }
 
         wxMenu *markmenu = new wxMenu();
-        MyAppend(markmenu, A_MARKDATA, _(L"&Data\tCTRL+ALT+d"));
-        MyAppend(markmenu, A_MARKCODE, _(L"&Operation\tCTRL+ALT+o"));
-        MyAppend(markmenu, A_MARKVARD, _(L"Variable &Assign\tCTRL+ALT+a"));
-        MyAppend(markmenu, A_MARKVARU, _(L"Variable &Read\tCTRL+ALT+r"));
-        MyAppend(markmenu, A_MARKVIEWH, _(L"&Horizontal View\tCTRL+ALT+."));
-        MyAppend(markmenu, A_MARKVIEWV, _(L"&Vertical View\tCTRL+ALT+,"));
+        MyAppend(markmenu, A_MARKDATA, _("&Data\tCTRL+ALT+d"));
+        MyAppend(markmenu, A_MARKCODE, _("&Operation\tCTRL+ALT+o"));
+        MyAppend(markmenu, A_MARKVARD, _("Variable &Assign\tCTRL+ALT+a"));
+        MyAppend(markmenu, A_MARKVARU, _("Variable &Read\tCTRL+ALT+r"));
+        MyAppend(markmenu, A_MARKVIEWH, _("&Horizontal View\tCTRL+ALT+."));
+        MyAppend(markmenu, A_MARKVIEWV, _("&Vertical View\tCTRL+ALT+,"));
 
         wxMenu *langmenu = new wxMenu();
-        MyAppend(langmenu, wxID_EXECUTE, _(L"&Run\tCTRL+ALT+F5"));
-        langmenu->AppendSubMenu(markmenu, _(L"&Mark as"));
-        MyAppend(langmenu, A_CLRVIEW, _(L"&Clear Views"));
+        MyAppend(langmenu, wxID_EXECUTE, _("&Run\tCTRL+ALT+F5"));
+        langmenu->AppendSubMenu(markmenu, _("&Mark as"));
+        MyAppend(langmenu, A_CLRVIEW, _("&Clear Views"));
 
         wxMenu *helpmenu = new wxMenu();
-        MyAppend(helpmenu, wxID_ABOUT, _(L"&About..."));
-        MyAppend(helpmenu, wxID_HELP, _(L"Load interactive &tutorial...\tF1"));
-        MyAppend(helpmenu, A_HELP_OP_REF, _(L"Load operation reference...\tCTRL+ALT+F1"));
-        MyAppend(helpmenu, A_HELP, _(L"View tutorial &web page..."));
+        MyAppend(helpmenu, wxID_ABOUT, _("&About..."));
+        MyAppend(helpmenu, wxID_HELP, _("Load interactive &tutorial...\tF1"));
+        MyAppend(helpmenu, A_HELP_OP_REF, _("Load operation reference...\tCTRL+ALT+F1"));
+        MyAppend(helpmenu, A_HELP, _("View tutorial &web page..."));
 
         wxAcceleratorEntry entries[3];
         entries[0].Set(wxACCEL_SHIFT, WXK_DELETE, wxID_CUT);
@@ -649,18 +649,18 @@ struct MyFrame : wxFrame {
         SetAcceleratorTable(accel);
 
         wxMenuBar *menubar = new wxMenuBar();
-        menubar->Append(filemenu, _(L"&File"));
-        menubar->Append(editmenu, _(L"&Edit"));
-        menubar->Append(semenu, _(L"&Search"));
-        menubar->Append(viewmenu, _(L"&View"));
-        menubar->Append(optmenu, _(L"&Options"));
-        menubar->Append(scriptmenu, _(L"Script"));
-        menubar->Append(langmenu, _(L"&Program"));
+        menubar->Append(filemenu, _("&File"));
+        menubar->Append(editmenu, _("&Edit"));
+        menubar->Append(semenu, _("&Search"));
+        menubar->Append(viewmenu, _("&View"));
+        menubar->Append(optmenu, _("&Options"));
+        menubar->Append(scriptmenu, _("Script"));
+        menubar->Append(langmenu, _("&Program"));
         menubar->Append(helpmenu,
                         #ifdef __WXMAC__
                         wxApp::s_macHelpMenuTitleName  // so merges with osx provided help
                         #else
-                        _(L"&Help")
+                        _("&Help")
                         #endif
                         );
         #ifdef __WXMAC__
@@ -759,9 +759,9 @@ struct MyFrame : wxFrame {
         doc->sw = sw;
         sw->SetScrollRate(1, 1);
         if (append)
-            nb->AddPage(sw, _(L"<unnamed>"), true, wxNullBitmap);
+            nb->AddPage(sw, _("<unnamed>"), true, wxNullBitmap);
         else
-            nb->InsertPage(0, sw, _(L"<unnamed>"), true, wxNullBitmap);
+            nb->InsertPage(0, sw, _("<unnamed>"), true, wxNullBitmap);
         sw->SetDropTarget(new DropTarget(doc->dndobjc));
         sw->SetFocus();
         return sw;
@@ -818,7 +818,7 @@ struct MyFrame : wxFrame {
         if (page < 0) return;
         if (page == nb->GetSelection()) SetTitle(L"TreeSheets - " + fn + mods);
         nb->SetPageText(page,
-                        (fn.empty() ? wxString(_(L"<unnamed>")) : wxFileName(fn).GetName()) + mods);
+                        (fn.empty() ? wxString(_("<unnamed>")) : wxFileName(fn).GetName()) + mods);
     }
 
     void ConstructToolBar() {
@@ -841,57 +841,57 @@ struct MyFrame : wxFrame {
                         name, wxITEM_NORMAL);
         };
 
-        AddTBIcon(_(L"New (CTRL+n)"), wxID_NEW, iconpath, L"filenew.svg", L"filenew_dark.svg");
-        AddTBIcon(_(L"Open (CTRL+o)"), wxID_OPEN, iconpath, L"fileopen.svg", L"fileopen_dark.svg");
-        AddTBIcon(_(L"Save (CTRL+s)"), wxID_SAVE, iconpath, L"filesave.svg", L"filesave_dark.svg");
-        AddTBIcon(_(L"Save As"), wxID_SAVEAS, iconpath, L"filesaveas.svg", L"filesaveas_dark.svg");
+        AddTBIcon(_("New (CTRL+n)"), wxID_NEW, iconpath, L"filenew.svg", L"filenew_dark.svg");
+        AddTBIcon(_("Open (CTRL+o)"), wxID_OPEN, iconpath, L"fileopen.svg", L"fileopen_dark.svg");
+        AddTBIcon(_("Save (CTRL+s)"), wxID_SAVE, iconpath, L"filesave.svg", L"filesave_dark.svg");
+        AddTBIcon(_("Save As"), wxID_SAVEAS, iconpath, L"filesaveas.svg", L"filesaveas_dark.svg");
         SEPARATOR;
-        AddTBIcon(_(L"Undo (CTRL+z)"), wxID_UNDO, iconpath, L"undo.svg", L"undo_dark.svg");
-        AddTBIcon(_(L"Copy (CTRL+c)"), wxID_COPY, iconpath, L"editcopy.svg", L"editcopy_dark.svg");
-        AddTBIcon(_(L"Paste (CTRL+v)"), wxID_PASTE, iconpath, L"editpaste.svg",
+        AddTBIcon(_("Undo (CTRL+z)"), wxID_UNDO, iconpath, L"undo.svg", L"undo_dark.svg");
+        AddTBIcon(_("Copy (CTRL+c)"), wxID_COPY, iconpath, L"editcopy.svg", L"editcopy_dark.svg");
+        AddTBIcon(_("Paste (CTRL+v)"), wxID_PASTE, iconpath, L"editpaste.svg",
                   L"editpaste_dark.svg");
         SEPARATOR;
-        AddTBIcon(_(L"Zoom In (CTRL+mousewheel)"), A_ZOOMIN, iconpath, L"zoomin.svg",
+        AddTBIcon(_("Zoom In (CTRL+mousewheel)"), A_ZOOMIN, iconpath, L"zoomin.svg",
                   L"zoomin_dark.svg");
-        AddTBIcon(_(L"Zoom Out (CTRL+mousewheel)"), A_ZOOMOUT, iconpath, L"zoomout.svg",
+        AddTBIcon(_("Zoom Out (CTRL+mousewheel)"), A_ZOOMOUT, iconpath, L"zoomout.svg",
                   L"zoomout_dark.svg");
         SEPARATOR;
-        AddTBIcon(_(L"New Grid (INS)"), A_NEWGRID, iconpath, L"newgrid.svg", L"newgrid_dark.svg");
-        AddTBIcon(_(L"Add Image"), A_IMAGE, iconpath, L"image.svg", L"image_dark.svg");
+        AddTBIcon(_("New Grid (INS)"), A_NEWGRID, iconpath, L"newgrid.svg", L"newgrid_dark.svg");
+        AddTBIcon(_("Add Image"), A_IMAGE, iconpath, L"image.svg", L"image_dark.svg");
         SEPARATOR;
-        AddTBIcon(_(L"Run"), wxID_EXECUTE, iconpath, L"run.svg", L"run_dark.svg");
+        AddTBIcon(_("Run"), wxID_EXECUTE, iconpath, L"run.svg", L"run_dark.svg");
         tb->AddSeparator();
-        tb->AddControl(new wxStaticText(tb, wxID_ANY, _(L"Search ")));
+        tb->AddControl(new wxStaticText(tb, wxID_ANY, _("Search ")));
         tb->AddControl(filter = new wxTextCtrl(tb, A_SEARCH, "", wxDefaultPosition,
                                                FromDIP(wxSize(80, 22)),
                                                wxWANTS_CHARS | wxTE_PROCESS_ENTER));
-        AddTBIcon(_(L"Clear search"), A_CLEARSEARCH, iconpath, L"cancel.svg", L"cancel_dark.svg");
-        AddTBIcon(_(L"Go to Next Search Result"), A_SEARCHNEXT, iconpath, L"search.svg",
+        AddTBIcon(_("Clear search"), A_CLEARSEARCH, iconpath, L"cancel.svg", L"cancel_dark.svg");
+        AddTBIcon(_("Go to Next Search Result"), A_SEARCHNEXT, iconpath, L"search.svg",
                   L"search_dark.svg");
         SEPARATOR;
-        tb->AddControl(new wxStaticText(tb, wxID_ANY, _(L"Replace ")));
+        tb->AddControl(new wxStaticText(tb, wxID_ANY, _("Replace ")));
         tb->AddControl(replaces = new wxTextCtrl(tb, A_REPLACE, "", wxDefaultPosition,
                                                  FromDIP(wxSize(80, 22)),
                                                  wxWANTS_CHARS | wxTE_PROCESS_ENTER));
-        AddTBIcon(_(L"Clear replace"), A_CLEARREPLACE, iconpath, L"cancel.svg", L"cancel_dark.svg");
-        AddTBIcon(_(L"Replace in selection"), A_REPLACEONCE, iconpath, L"replace.svg",
+        AddTBIcon(_("Clear replace"), A_CLEARREPLACE, iconpath, L"cancel.svg", L"cancel_dark.svg");
+        AddTBIcon(_("Replace in selection"), A_REPLACEONCE, iconpath, L"replace.svg",
                   L"replace_dark.svg");
-        AddTBIcon(_(L"Replace All"), A_REPLACEALL, iconpath, L"replaceall.svg",
+        AddTBIcon(_("Replace All"), A_REPLACEALL, iconpath, L"replaceall.svg",
                   L"replaceall_dark.svg");
         tb->AddSeparator();
-        tb->AddControl(new wxStaticText(tb, wxID_ANY, _(L"Cell ")));
+        tb->AddControl(new wxStaticText(tb, wxID_ANY, _("Cell ")));
         celldd = new ColorDropdown(tb, A_CELLCOLOR, 1);
         tb->AddControl(celldd);
         SEPARATOR;
-        tb->AddControl(new wxStaticText(tb, wxID_ANY, _(L"Text ")));
+        tb->AddControl(new wxStaticText(tb, wxID_ANY, _("Text ")));
         textdd = new ColorDropdown(tb, A_TEXTCOLOR, 2);
         tb->AddControl(textdd);
         SEPARATOR;
-        tb->AddControl(new wxStaticText(tb, wxID_ANY, _(L"Border ")));
+        tb->AddControl(new wxStaticText(tb, wxID_ANY, _("Border ")));
         borddd = new ColorDropdown(tb, A_BORDCOLOR, 7);
         tb->AddControl(borddd);
         tb->AddSeparator();
-        tb->AddControl(new wxStaticText(tb, wxID_ANY, _(L"Image ")));
+        tb->AddControl(new wxStaticText(tb, wxID_ANY, _("Image ")));
         idd = new ImageDropdown(tb, imagepath);
         tb->AddControl(idd);
         tb->Realize();
@@ -971,7 +971,7 @@ struct MyFrame : wxFrame {
         sw->doc->ShiftToCenter(dc);
         auto Check = [&](const wxChar *cfg) {
             sys->cfg->Write(cfg, ce.IsChecked());
-            sw->Status(_(L"change will take effect next run of TreeSheets"));
+            sw->Status(_("change will take effect next run of TreeSheets"));
         };
         switch (ce.GetId()) {
             case A_NOP: break;
@@ -1036,14 +1036,14 @@ struct MyFrame : wxFrame {
                 break;
             case A_FULLSCREEN:
                 ShowFullScreen(!IsFullScreen());
-                if (IsFullScreen()) sw->Status(_(L"Press F11 to exit fullscreen mode."));
+                if (IsFullScreen()) sw->Status(_("Press F11 to exit fullscreen mode."));
                 break;
             case wxID_FIND:
                 if (filter) {
                     filter->SetFocus();
                     filter->SetSelection(0, 1000);
                 } else {
-                    sw->Status(_(L"Please enable (Options -> Show Toolbar) to use search."));
+                    sw->Status(_("Please enable (Options -> Show Toolbar) to use search."));
                 }
                 break;
             case wxID_REPLACE:
@@ -1051,7 +1051,7 @@ struct MyFrame : wxFrame {
                     replaces->SetFocus();
                     replaces->SetSelection(0, 1000);
                 } else {
-                    sw->Status(_(L"Please enable (Options -> Show Toolbar) to use replace."));
+                    sw->Status(_("Please enable (Options -> Show Toolbar) to use replace."));
                 }
                 break;
             #ifdef __WXMAC__
@@ -1307,10 +1307,10 @@ struct MyFrame : wxFrame {
                     // for now, we leave this code active, and guard it with
                     // watcherwaitingforuser
                     wxString msg = wxString::Format(
-                        _(L"%s\nhas been modified on disk by another program / computer:\nWould you like to discard your changes and re-load from disk?"),
+                        _("%s\nhas been modified on disk by another program / computer:\nWould you like to discard your changes and re-load from disk?"),
                         doc->filename);
                     watcherwaitingforuser = true;
-                    int res = wxMessageBox(msg, _(L"File modification conflict!"),
+                    int res = wxMessageBox(msg, _("File modification conflict!"),
                                            wxYES_NO | wxICON_QUESTION, this);
                     watcherwaitingforuser = false;
                     if (res != wxYES) return;
@@ -1324,7 +1324,7 @@ struct MyFrame : wxFrame {
                         nb->DeletePage(j);
                     ::wxRemoveFile(sys->TmpName(modfile));
                     GetCurTab()->Status(
-                        _(L"File has been re-loaded because of modifications of another program / computer"));
+                        _("File has been re-loaded because of modifications of another program / computer"));
                 }
                 return;
             }

--- a/src/mywxtools.h
+++ b/src/mywxtools.h
@@ -65,18 +65,18 @@ struct ThreeChoiceDialog : public wxDialog {
 };
 
 struct DateTimeRangeDialog : public wxDialog {
-    wxStaticText introtext {this, wxID_ANY, _(L"Please select the datetime range.")};
-    wxStaticText starttext {this, wxID_ANY, _(L"Start date and time")};
+    wxStaticText introtext {this, wxID_ANY, _("Please select the datetime range.")};
+    wxStaticText starttext {this, wxID_ANY, _("Start date and time")};
     wxDatePickerCtrl startdate {this, wxID_ANY};
     wxTimePickerCtrl starttime {this, wxID_ANY};
-    wxStaticText endtext {this, wxID_ANY, _(L"End date and time")};
+    wxStaticText endtext {this, wxID_ANY, _("End date and time")};
     wxDatePickerCtrl enddate {this, wxID_ANY};
     wxTimePickerCtrl endtime {this, wxID_ANY};
-    wxButton okbtn {this, wxID_OK, _(L"Filter")};
-    wxButton cancelbtn {this, wxID_CANCEL, _(L"Cancel")};
+    wxButton okbtn {this, wxID_OK, _("Filter")};
+    wxButton cancelbtn {this, wxID_CANCEL, _("Cancel")};
     wxDateTime begin;
     wxDateTime end;
-    DateTimeRangeDialog(wxWindow *parent) : wxDialog(parent, wxID_ANY, _(L"Date and time range")) {
+    DateTimeRangeDialog(wxWindow *parent) : wxDialog(parent, wxID_ANY, _("Date and time range")) {
         wxSizerFlags sizerflags(1);
         wxFlexGridSizer *startsizer = new wxFlexGridSizer(2, wxSize(5, 5));
         startsizer->Add(&startdate, 0, wxALL, 5);

--- a/src/system.h
+++ b/src/system.h
@@ -235,8 +235,8 @@ struct System {
 
             if (::wxFileExists(TmpName(filename))) {
                 if (::wxMessageBox(
-                        _(L"A temporary autosave file exists, would you like to load it instead?"),
-                        _(L"Autosave load"), wxYES_NO, frame) == wxYES) {
+                        _("A temporary autosave file exists, would you like to load it instead?"),
+                        _("Autosave load"), wxYES_NO, frame) == wxYES) {
                     fn = TmpName(filename);
                     loadedfromtmp = true;
                 }
@@ -252,13 +252,13 @@ struct System {
             Cell *ics = nullptr;
             wxFFileInputStream fis(fn);
             wxDataInputStream dis(fis);
-            if (!fis.IsOk()) return _(L"Cannot open file.");
+            if (!fis.IsOk()) return _("Cannot open file.");
 
             char buf[4];
             fis.Read(buf, 4);
-            if (strncmp(buf, "TSFF", 4)) return _(L"Not a TreeSheets file.");
+            if (strncmp(buf, "TSFF", 4)) return _("Not a TreeSheets file.");
             fis.Read(&versionlastloaded, 1);
-            if (versionlastloaded > TS_VERSION) return _(L"File of newer version.");
+            if (versionlastloaded > TS_VERSION) return _("File of newer version.");
             int xs, ys;
             if (versionlastloaded >= 21) {
                 xs = dis.Read8();
@@ -279,7 +279,7 @@ struct System {
                         char iti = *buf;
                         auto mapitem = imagetypes.find(iti);
                         if (mapitem == imagetypes.end())
-                            return _(L"Found an image type that is not defined in this program.");
+                            return _("Found an image type that is not defined in this program.");
                         if (versionlastloaded < 9) dis.ReadString();
                         double sc = versionlastloaded >= 19 ? dis.ReadDouble() : 1.0;
                         vector<uint8_t> image_data;
@@ -294,7 +294,7 @@ struct System {
                                 uchar header[8];
                                 fis.Read(header, 8);
                                 uchar expected[] = {0x89, 'P', 'N', 'G', '\r', '\n', 0x1A, '\n'};
-                                if (memcmp(header, expected, 8)) return _(L"Corrupt PNG header.");
+                                if (memcmp(header, expected, 8)) return _("Corrupt PNG header.");
                                 dis.BigEndianOrdered(true);
                                 for (;;) {  // Skip all chunks.
                                     wxInt32 len = dis.Read32();
@@ -307,7 +307,7 @@ struct System {
                             } else if (iti == 'J') {
                                 wxImage im;
                                 im.LoadFile(fis);
-                                if (!im.IsOk()) { return _(L"JPEG file is corrupted!"); }
+                                if (!im.IsOk()) { return _("JPEG file is corrupted!"); }
                             }
 
                             off_t afterimage = fis.TellI();
@@ -325,11 +325,11 @@ struct System {
 
                     case 'D': {
                         wxZlibInputStream zis(fis);
-                        if (!zis.IsOk()) return _(L"Cannot decompress file.");
+                        if (!zis.IsOk()) return _("Cannot decompress file.");
                         wxDataInputStream dis(zis);
                         int numcells = 0, textbytes = 0;
                         Cell *root = Cell::LoadWhich(dis, nullptr, numcells, textbytes, ics);
-                        if (!root) return _(L"File corrupted!");
+                        if (!root) return _("File corrupted!");
 
                         doc = NewTabDoc(true);
                         if (loadedfromtmp) {
@@ -352,7 +352,7 @@ struct System {
 
                         doc->sw->Status(
                             wxString::Format(
-                                _(L"Loaded %s (%d cells, %d characters) in %d milliseconds."),
+                                _("Loaded %s (%d cells, %d characters) in %d milliseconds."),
                                 filename.c_str(), numcells, textbytes,
                                 (int)((end_loading_time - start_loading_time).GetValue()))
                                 .c_str());
@@ -360,7 +360,7 @@ struct System {
                         goto done;
                     }
 
-                    default: return _(L"Corrupt block header.");
+                    default: return _("Corrupt block header.");
                 }
             }
         }
@@ -382,8 +382,8 @@ struct System {
         FileUsed(filename, doc);
         doc->Refresh();
         if (anyimagesfailed)
-            wxMessageBox(_(L"PNG decode failed on some images in this document\nThey have been replaced by red squares."),
-                         _(L"PNG decoder failure"), wxOK, frame);
+            wxMessageBox(_("PNG decode failed on some images in this document\nThey have been replaced by red squares."),
+                         _("PNG decoder failure"), wxOK, frame);
 
         return L"";
     }
@@ -408,7 +408,7 @@ struct System {
             if (*msg) wxMessageBox(msg, fn.wx_str(), wxOK, frame);
             return msg;
         }
-        return _(L"Open file cancelled.");
+        return _("Open file cancelled.");
     }
 
     void RememberOpenFiles() {
@@ -431,10 +431,10 @@ struct System {
         if (frame->GetStatusBar()) {
             Cell *c = s.GetCell();
             if (c && s.xs) {
-                frame->SetStatusText(wxString::Format(_(L"Size %d"), -c->text.relsize), 3);
-                frame->SetStatusText(wxString::Format(_(L"Width %d"), s.g->colwidths[s.x]), 2);
+                frame->SetStatusText(wxString::Format(_("Size %d"), -c->text.relsize), 3);
+                frame->SetStatusText(wxString::Format(_("Width %d"), s.g->colwidths[s.x]), 2);
                 frame->SetStatusText(
-                    wxString::Format(_(L"Edited %s %s"), c->text.lastedit.FormatDate().c_str(),
+                    wxString::Format(_("Edited %s %s"), c->text.lastedit.FormatDate().c_str(),
                                      c->text.lastedit.FormatTime().c_str()),
                     1);
             }
@@ -443,7 +443,7 @@ struct System {
 
     void UpdateAmountStatus(Selection &s) {
         if (frame->GetStatusBar()) {
-            frame->SetStatusText(wxString::Format(_(L"%d cells"), s.xs * s.ys), 4);
+            frame->SetStatusText(wxString::Format(_("%d cells"), s.xs * s.ys), 4);
         }
     }
 
@@ -461,7 +461,7 @@ struct System {
     }
 
     const wxChar *Import(int k) {
-        wxString fn = ::wxFileSelector(_(L"Please select file to import:"), L"", L"", L"", L"*.*",
+        wxString fn = ::wxFileSelector(_("Please select file to import:"), L"", L"", L"", L"*.*",
                                        wxFD_OPEN | wxFD_FILE_MUST_EXIST | wxFD_CHANGE_DIR);
         if (!fn.empty()) {
             wxBusyCursor wait;
@@ -514,8 +514,8 @@ struct System {
         }
         return nullptr;
     problem:
-        wxMessageBox(_(L"couldn't import file!"), fn, wxOK, frame);
-        return _(L"File load error.");
+        wxMessageBox(_("couldn't import file!"), fn, wxOK, frame);
+        return _("File load error.");
     }
 
     int GetXMLNodes(wxXmlNode *n, vector<wxXmlNode *> &ns, vector<wxXmlAttribute *> *ps = nullptr,

--- a/src/treesheets_impl.h
+++ b/src/treesheets_impl.h
@@ -127,7 +127,7 @@ struct TreeSheetsScriptImpl : public ScriptInterface {
             flags |= wxFD_OVERWRITE_PROMPT | wxFD_SAVE;
         else
             flags |= wxFD_OPEN | wxFD_FILE_MUST_EXIST;
-        wxString fn = ::wxFileSelector(_(L"Choose file:"), L"", L"", L"", L"*.*", flags);
+        wxString fn = ::wxFileSelector(_("Choose file:"), L"", L"", L"", L"*.*", flags);
         auto s = fn.utf8_str();
         return std::string(s.data(), s.length());
     }


### PR DESCRIPTION
wxWidgets macro now expects `const char*` instead of `const wchar_t*`

```
.../Development/treesheets/src/myframe.h:130:26: error: no matching function for call to 'wxUnderscoreWrapper'
  130 |             wxMessageBox(_(L"Error loading core data file (TreeSheets not installed correctly?)"),
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.../Development/treesheets/lib/wxWidgets/include/wx/translation.h:48:48: note: expanded from macro '_'
   48 |     #define _(s)                               wxUnderscoreWrapper((s))
      |                                                ^~~~~~~~~~~~~~~~~~~
...//Development/treesheets/lib/wxWidgets/include/wx/translation.h:347:17: note: candidate template ignored: could not match 'const char' against 'const wchar_t'
  347 | const wxString& wxUnderscoreWrapper(const char (&msg)[N])
      |                 ^
```