### PR TITLE
Try to get full path on MacOS

### DIFF
--- a/src/myapp.h
+++ b/src/myapp.h
@@ -131,7 +131,11 @@ struct MyApp : wxApp {
         #endif
 
         auto exepath = argv[0];
-        #ifdef __WXGTK__
+        #if defined(__WXMAC__)
+            char path[PATH_MAX];
+            uint32_t size = sizeof(path);
+            if(_NSGetExecutablePath(path, &size) == 0) exepath = path;
+        #elif defined(__WXGTK__)
             // argv[0] could be relative, this is apparently a more robust way to get the
             // full path.
             char path[PATH_MAX];

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -85,4 +85,8 @@
     #include "StackWalker\StackWalkerHelpers.h"
 #endif
 
+#ifdef __WXMAC__
+    #include <mach-o/dyld.h>
+#endif
+
 using namespace std;


### PR DESCRIPTION
When the executable is launched in its sitting directory, argv[0] is only "./TreeSheets". This will fail MyFrame::GetDataDir because it needs the full path.

See dyld(3) for details with regards to _NSGetExecutablePath.