### PR TITLE
Avoid conflict with macOS headers over DirInfo

### DIFF
--- a/lobster/src/compiler.cpp
+++ b/lobster/src/compiler.cpp
@@ -166,7 +166,7 @@ string BuildPakFile(string &pakfile, string &bytecode, set<string> &files, uint6
                 pat = filename.substr(pos + 1);
                 base = filename.substr(0, pos);
             }
-            vector<DirInfo> dir;
+            vector<DirectoryInfo> dir;
             if (!ScanDir(base, dir)) return "cannot load file/dir for pakfile: " + filename;
             for (auto &entry : dir) {
                 if (!pat.empty() && entry.name.find(pat) == entry.name.npos) continue;

--- a/lobster/src/file.cpp
+++ b/lobster/src/file.cpp
@@ -169,7 +169,7 @@ nfr("scan_folder", "folder,rel", "SB?", "S]?I]?I]?",
     " set rel use a relative path, default is absolute."
     " Returns nil if folder couldn't be scanned.",
     [](StackPtr &sp, VM &vm, Value &fld, Value &rel) {
-        vector<DirInfo> dir;
+        vector<DirectoryInfo> dir;
         auto ok = rel.True()
             ? ScanDir(fld.sval()->strv(), dir)
             : ScanDirAbs(fld.sval()->strv(), dir);

--- a/lobster/src/lobster/platform.h
+++ b/lobster/src/lobster/platform.h
@@ -54,14 +54,15 @@ extern string SanitizePath(string_view path);
 extern void AddPakFileEntry(string_view pakfilename, string_view relfilename, int64_t off,
                             int64_t len, int64_t uncompressed);
 
-struct DirInfo {
+// Avoid a conflict with macOS headers which define DirInfo differently.
+struct DirectoryInfo {
     string name;
     int64_t size = 0;
     filesystem::file_time_type last_write_time;
 };
 
-extern bool ScanDir(string_view reldir, vector<DirInfo> &dest);
-extern bool ScanDirAbs(string_view absdir, vector<DirInfo> &dest);
+extern bool ScanDir(string_view reldir, vector<DirectoryInfo> &dest);
+extern bool ScanDirAbs(string_view absdir, vector<DirectoryInfo> &dest);
 
 extern iint LaunchSubProcess(const char **cmdl, const char *stdins, string &out);
 

--- a/lobster/src/platform.cpp
+++ b/lobster/src/platform.cpp
@@ -429,7 +429,7 @@ bool FileDelete(string_view relfilename) {
     return false;
 }
 
-bool ScanDirAbs(string_view absdir, vector<DirInfo> &dest) {
+bool ScanDirAbs(string_view absdir, vector<DirectoryInfo> &dest) {
     using namespace filesystem;
     string folder = SanitizePath(absdir);
     #if !defined(PLATFORM_ES3)
@@ -451,7 +451,7 @@ bool ScanDirAbs(string_view absdir, vector<DirInfo> &dest) {
     return false;
 }
 
-bool ScanDir(string_view reldir, vector<DirInfo> &dest) {
+bool ScanDir(string_view reldir, vector<DirectoryInfo> &dest) {
     // First check the pakfile.
     for (auto [prfn, tup] : pakfile_registry) {
         if (prfn.find(reldir) == 0) {


### PR DESCRIPTION
Using `DirInfo` creates a conflict with macOS system headers, where it is defined differently. Change the name so that a conflict is avoided.

```
[ 50%] Building CXX object CMakeFiles/lobster.dir/lobster/src/platform.cpp.o
/opt/local/bin/g++-mp-14 -DWXUSINGDLL -D_FILE_OFFSET_BITS=64 -D__WXGTK3__ -D__WXGTK__ -I/opt/local/var/macports/build/_opt_local_ppcports_editors_treesheets/treesheets/work/treesheets-14020763227/lobster/include -I/opt/local/var/macports/build/_opt_local_ppcports_editors_treesheets/treesheets/work/treesheets-14020763227/lobster/src -I/opt/local/var/macports/build/_opt_local_ppcports_editors_treesheets/treesheets/work/treesheets-14020763227/lobster/external/libtcc -isystem /opt/local/Library/Frameworks/wxWidgets.framework/Versions/wxGTK/3.2/lib/wx/include/gtk3-unicode-3.2 -isystem /opt/local/Library/Frameworks/wxWidgets.framework/Versions/wxGTK/3.2/include/wx-3.2 -pipe -Os -DNDEBUG -I/opt/local/include -D_GLIBCXX_USE_CXX11_ABI=0 -Wno-array-bounds -Wno-stringop-overflow -Wno-maybe-uninitialized -std=gnu++20 -arch ppc -mmacosx-version-min=10.6 -MD -MT CMakeFiles/lobster.dir/lobster/src/platform.cpp.o -MF CMakeFiles/lobster.dir/lobster/src/platform.cpp.o.d -o CMakeFiles/lobster.dir/lobster/src/platform.cpp.o -c /opt/local/var/macports/build/_opt_local_ppcports_editors_treesheets/treesheets/work/treesheets-14020763227/lobster/src/platform.cpp
[ 55%] Building CXX object CMakeFiles/lobster.dir/lobster/src/tccbind.cpp.o
/opt/local/bin/g++-mp-14 -DWXUSINGDLL -D_FILE_OFFSET_BITS=64 -D__WXGTK3__ -D__WXGTK__ -I/opt/local/var/macports/build/_opt_local_ppcports_editors_treesheets/treesheets/work/treesheets-14020763227/lobster/include -I/opt/local/var/macports/build/_opt_local_ppcports_editors_treesheets/treesheets/work/treesheets-14020763227/lobster/src -I/opt/local/var/macports/build/_opt_local_ppcports_editors_treesheets/treesheets/work/treesheets-14020763227/lobster/external/libtcc -isystem /opt/local/Library/Frameworks/wxWidgets.framework/Versions/wxGTK/3.2/lib/wx/include/gtk3-unicode-3.2 -isystem /opt/local/Library/Frameworks/wxWidgets.framework/Versions/wxGTK/3.2/include/wx-3.2 -pipe -Os -DNDEBUG -I/opt/local/include -D_GLIBCXX_USE_CXX11_ABI=0 -Wno-array-bounds -Wno-stringop-overflow -Wno-maybe-uninitialized -std=gnu++20 -arch ppc -mmacosx-version-min=10.6 -MD -MT CMakeFiles/lobster.dir/lobster/src/tccbind.cpp.o -MF CMakeFiles/lobster.dir/lobster/src/tccbind.cpp.o.d -o CMakeFiles/lobster.dir/lobster/src/tccbind.cpp.o -c /opt/local/var/macports/build/_opt_local_ppcports_editors_treesheets/treesheets/work/treesheets-14020763227/lobster/src/tccbind.cpp
In file included from /System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/Components.h:32,
                 from /System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/CarbonCore.h:85,
                 from /System/Library/Frameworks/CoreServices.framework/Frameworks/AE.framework/Headers/AE.h:20,
                 from /System/Library/Frameworks/CoreServices.framework/Headers/CoreServices.h:21,
                 from /System/Library/Frameworks/Carbon.framework/Headers/Carbon.h:20,
                 from /opt/local/var/macports/build/_opt_local_ppcports_editors_treesheets/treesheets/work/treesheets-14020763227/lobster/src/platform.cpp:49:
/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/Files.h:543:8: error: redefinition of 'struct DirInfo'
  543 | struct DirInfo {
      |        ^~~~~~~
In file included from /opt/local/var/macports/build/_opt_local_ppcports_editors_treesheets/treesheets/work/treesheets-14020763227/lobster/src/lobster/stdafx.h:93,
                 from /opt/local/var/macports/build/_opt_local_ppcports_editors_treesheets/treesheets/work/treesheets-14020763227/lobster/src/platform.cpp:17:
/opt/local/var/macports/build/_opt_local_ppcports_editors_treesheets/treesheets/work/treesheets-14020763227/lobster/src/lobster/platform.h:57:8: note: previous definition of 'struct DirInfo'
   57 | struct DirInfo {
      |        ^~~~~~~
```