### PR TITLE
Only add to undo stack if a script is actually run

### DIFF
--- a/src/treesheets_impl.h
+++ b/src/treesheets_impl.h
@@ -9,11 +9,11 @@ struct TreeSheetsScriptImpl : public ScriptInterface {
     void SwitchToCurrentDoc() {
         doc = sys->frame->GetCurTab()->doc;
         cur = doc->rootgrid;
-        doc->AddUndo(cur);
     }
 
     std::string ScriptRun(const char *filename, wxDC &_dc) {
         SwitchToCurrentDoc();
+        doc->AddUndo(cur);
 
         bool dump_builtins = false;
         #ifdef _DEBUG


### PR DESCRIPTION
This avoids the newly opened Document to be added to the undo stack and thus be marked as modified although there has not been modified anything.