### PR TITLE
Add single steps in scripts to undo stack

### DIFF
--- a/src/treesheets_impl.h
+++ b/src/treesheets_impl.h
@@ -9,7 +9,6 @@ struct TreeSheetsScriptImpl : public ScriptInterface {
     void SwitchToCurrentDoc() {
         doc = sys->frame->GetCurTab()->doc;
         cur = doc->rootgrid;
-        doc->AddUndo(cur);
     }
 
     std::string ScriptRun(const char *filename, wxDC &_dc) {
@@ -77,22 +76,27 @@ struct TreeSheetsScriptImpl : public ScriptInterface {
     }
 
     void SetText(std::string_view t) {
+        doc->AddUndo(cur);
         if (cur->parent) cur->text.t = wxString::FromUTF8(t.data(), t.size());
     }
 
     void CreateGrid(int x, int y) {
+        doc->AddUndo(cur);
         if (x > 0 && y > 0 && x * y < max_new_grid_cells) cur->AddGrid(x, y);
     }
 
     void InsertColumn(int x) {
+        doc->AddUndo(cur);
         if (cur->grid && x >= 0 && x <= cur->grid->xs) cur->grid->InsertCells(x, -1, 1, 0);
     }
 
     void InsertRow(int y) {
+        doc->AddUndo(cur);
         if (cur->grid && y >= 0 && y <= cur->grid->ys) cur->grid->InsertCells(-1, y, 0, 1);
     }
 
     void Delete(int x, int y, int xs, int ys) {
+        doc->AddUndo(cur);
         if (cur->grid && x >= 0 && x + xs <= cur->grid->xs && y >= 0 && y + ys <= cur->grid->ys) {
             Selection s(cur->grid, x, y, xs, ys);
             cur->grid->MultiCellDeleteSub(doc, s);
@@ -101,17 +105,31 @@ struct TreeSheetsScriptImpl : public ScriptInterface {
         }
     }
 
-    void SetBackgroundColor(uint col) { cur->cellcolor = col; }
-    void SetTextColor(uint col) { cur->textcolor = col; }
+    void SetBackgroundColor(uint col) {
+        doc->AddUndo(cur);
+        cur->cellcolor = col;
+    }
+    void SetTextColor(uint col) {
+        doc->AddUndo(cur);
+        cur->textcolor = col;
+    }
     void SetTextFiltered(bool filtered) {
+        doc->AddUndo(cur);
         if (cur->parent) cur->text.filtered = filtered;
     }
     bool IsTextFiltered() { return cur->text.filtered; }
     void SetBorderColor(uint col) {
+        doc->AddUndo(cur);
         if (cur->grid) cur->grid->bordercolor = col;
     }
-    void SetRelativeSize(int s) { cur->text.relsize = s; }
-    void SetStyle(int s) { cur->text.stylebits = s; }
+    void SetRelativeSize(int s) {
+        doc->AddUndo(cur);
+        cur->text.relsize = s;
+    }
+    void SetStyle(int s) {
+        doc->AddUndo(cur);
+        cur->text.stylebits = s;
+    }
 
     void SetStatusMessage(std::string_view msg) {
         auto ws = wxString(msg.data(), msg.size());


### PR DESCRIPTION
This has following trade-off:

Positive:
+ Only marks documents as modified when they are (undo stack is used)
+ Can undo single steps in scripts which is good when one step does not do what it was intended to do

Negative:
- Script modifications cannot be undone all at once.