### PR TITLE
Fix race condition with consecutive releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         tag: ${{ github.run_id }}
         allowUpdates: true
         omitBody: true
-        commit: master
+        commit: ${{ github.sha }}
         artifacts: "_build/treesheets_*.deb"
     - name: Upload artifacts
       if: github.ref != 'refs/heads/master'
@@ -64,7 +64,7 @@ jobs:
         tag: ${{ github.run_id }}
         allowUpdates: true
         omitBody: true
-        commit: master
+        commit: ${{ github.sha }}
         artifacts: "_build/TreeSheets-*.exe, _build/TreeSheets-*.zip"
     - name: Upload artifacts
       if: github.ref != 'refs/heads/master'
@@ -100,7 +100,7 @@ jobs:
         tag: ${{ github.run_id }}
         allowUpdates: true
         omitBody: true
-        commit: master
+        commit: ${{ github.sha }}
         artifacts: "_build/TreeSheets-*.dmg"
     - name: Upload artifacts
       if: github.ref != 'refs/heads/master'


### PR DESCRIPTION
Fix the problem with consecutive commits causing the earlier release to tag the
wrong commit and have wrong release notes.

What happened was:
1. push to master (commit A)
2. CI run 1001 starts, triggered by A
3. push to master (commit B)
4. CI run 1002 starts, triggered by B
5. CI run 1001 reaches the ncipollo/release-action step and tags _current_
   master (B) as tag `1001`, even though the release is built with commit A
6. CI run 1002 reaches the ncipollo/release-action step and tags _current_
   master (B) as tag `1002`

Result, there are 2 tags `1001` and `1002` pointing to commit B, and no tags
pointing to commit A.

Can see the difference in the build log:
- Latest build here where it tags `master`:
  https://github.com/aardappel/treesheets/actions/runs/14600564602/job/40957440142#step:9:6
- Example with this change, it tags the commit that triggered the run:
  https://github.com/jn64/treesheets/actions/runs/14601649695/job/40961008208#step:9:6