### PR TITLE
WIP: Use less wxClientDC

### DIFF
--- a/src/mycanvas.h
+++ b/src/mycanvas.h
@@ -23,15 +23,7 @@ struct TSCanvas : public wxScrolledCanvas {
     }
 
     void OnPaint(wxPaintEvent &event) {
-        #if defined(__WXMAC__) || defined(__WXGTK__)
-            wxPaintDC dc(this);
-        #else
-            auto sz = GetClientSize();
-            if (sz.GetX() <= 0 || sz.GetY() <= 0) return;
-            wxBitmap buffer(sz.GetX(), sz.GetY(), 24);
-            wxBufferedPaintDC dc(this, buffer);
-        #endif
-        // DoPrepareDC(dc);
+        wxPaintDC dc(this);
         doc->Draw(dc);
         // Display has been re-layouted, compute hover selection again.
         // TODO: lastmousepos doesn't seem correct anymore after a scroll operation in latest

--- a/src/selection.h
+++ b/src/selection.h
@@ -134,7 +134,8 @@ class Selection {
             // FIXME: this is null in the case of a whole column selection, and doesn't do the right
             // thing.
             if (g) g->cell->ResetChildren();
-            doc->ScrollIfSelectionOutOfView(dc, *this, true);
+            doc->scrolltoselection = true;
+            doc->Refresh();
         } else {
             doc->DrawSelect(dc, *this);
             if (ctrl && dx)  // implies textedit
@@ -300,7 +301,8 @@ class Selection {
                     }
                 };
             }
-            doc->DrawSelectMove(dc, *this);
+            doc->scrolltoselection = true;
+            doc->Refresh();
             doc->ResetBlink();
         };
     }
@@ -321,7 +323,6 @@ class Selection {
     }
 
     void Next(Document *doc, wxDC &dc, bool backwards) {
-        doc->DrawSelect(dc, *this);
         ExitEdit(doc);
         if (backwards) {
             if (x > 0)
@@ -343,7 +344,8 @@ class Selection {
                 x = y = 0;
         }
         EnterEdit(doc, 0, MaxCursor());
-        doc->DrawSelectMove(dc, *this);
+        doc->scrolltoselection = true;
+        doc->Refresh();
     }
 
     const wxChar *Wrap(Document *doc) {
@@ -387,7 +389,6 @@ class Selection {
     }
 
     void HomeEnd(Document *doc, wxDC &dc, bool ishome) {
-        doc->DrawSelect(dc, *this);
         xs = ys = 1;
         if (ishome)
             x = y = 0;
@@ -395,6 +396,7 @@ class Selection {
             x = g->xs - 1;
             y = g->ys - 1;
         }
-        doc->DrawSelectMove(dc, *this);
+        doc->scrolltoselection = true;
+        doc->Refresh();
     }
 };


### PR DESCRIPTION
- Dissolve DrawSelectMove because only scrolltoselection needs to be set and Refresh triggered
- Use ScrollIfSelectionOutOfView only with wxPaintDC