### PR TITLE
wxPaintDC rewrite

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -32,7 +32,6 @@ struct Document {
     int fgutter {6};
     int lasttextsize;
     int laststylebits;
-    int initialzoomlevel {0};
     Cell *curdrawroot;  // for use during Render() calls
     vector<unique_ptr<UndoItem>> undolist;
     vector<unique_ptr<UndoItem>> redolist;
@@ -550,10 +549,6 @@ struct Document {
         dc.Clear();
         if (!rootgrid) return;
         sw->GetClientSize(&maxx, &maxy);
-        if (initialzoomlevel) {
-            ZoomSetDrawPath(initialzoomlevel);
-            initialzoomlevel = 0;
-        }
         Layout(dc);
         double xscale = maxx / (double)layoutxs;
         double yscale = maxy / (double)layoutys;

--- a/src/document.h
+++ b/src/document.h
@@ -218,16 +218,11 @@ struct Document {
         return _(L"");
     }
 
-    void DrawSelect(wxDC &dc, Selection &sel, bool refreshinstead = false,
-                    bool cursoronly = false) {
+    void DrawSelect(wxDC &dc, Selection &sel) {
         sys->UpdateAmountStatus(sel);
-        if (refreshinstead) {
-            sw->Refresh();
-            return;
-        }
         if (!sel.g) return;
         ResetFont();
-        sel.g->DrawSelect(this, dc, sel, cursoronly);
+        sel.g->DrawSelect(this, dc, sel);
     }
 
     void RefreshMove(Selection &sel) {
@@ -327,8 +322,8 @@ struct Document {
         if (selected.GetCell() == hover.GetCell() && hover.GetCell()) hover.EnterEditOnly(this);
         SetSelect(hover);
         isctrlshiftdrag = isctrlshift;
-        RefreshMove(selected);
         ResetCursor();
+        RefreshMove(selected);
         return;
     }
 

--- a/src/document.h
+++ b/src/document.h
@@ -499,8 +499,7 @@ struct Document {
                 selected.g->cell->ResetLayout();
                 selected.g->cell->ResetChildren();
                 sys->UpdateStatus(selected);
-                scrolltoselection = true;
-                Refresh();
+                RefreshMove(selected);
                 return dir > 0 ? _(L"Column width increased.") : _(L"Column width decreased.");
             }
             return L"nothing to resize";
@@ -510,8 +509,7 @@ struct Document {
             selected.g->ResetChildren();
             selected.g->RelSize(-dir, selected, pathscalebias);
             sys->UpdateStatus(selected);
-            scrolltoselection = true;
-            Refresh();
+            RefreshMove(selected);
             return dir > 0 ? _(L"Text size increased.") : _(L"Text size decreased.");
         } else if (ctrl) {
             int steps = abs(dir);

--- a/src/document.h
+++ b/src/document.h
@@ -246,11 +246,9 @@ struct Document {
         sys->UpdateStatus(hover);
     }
 
-    bool ScrollIfSelectionOutOfView(wxDC &dc, Selection &sel, bool refreshalways = false,
-                                    bool needslayout = true) {
+    void ScrollIfSelectionOutOfView(wxDC &dc, Selection &sel) {
         if (!scaledviewingmode) {
             // required, since sizes of things may have been reset by the last editing operation
-            if (needslayout) Layout(dc);
             int canvasw, canvash;
             sw->GetClientSize(&canvasw, &canvash);
             if ((layoutys > canvash || layoutxs > canvasw) && sel.g) {
@@ -269,13 +267,10 @@ struct Document {
                                           ? r.y + r.height - canvash + wxSYS_HSCROLL_Y
                                           : cury,
                                       true);
-                    if (needslayout) sw->Refresh();
-                    return true;
                 }
             }
         }
-        if (refreshalways) sw->Refresh();
-        return refreshalways;
+
     }
 
     void ScrollOrZoom(bool zoomiftiny = false) {
@@ -612,7 +607,7 @@ struct Document {
         Render(dc);
         DrawSelect(dc, selected);
         if (scrolltoselection) {
-            ScrollIfSelectionOutOfView(dc, selected, false, false);
+            ScrollIfSelectionOutOfView(dc, selected);
             scrolltoselection = false;
         }
         if (scaledviewingmode) { dc.SetUserScale(1, 1); }

--- a/src/document.h
+++ b/src/document.h
@@ -268,7 +268,7 @@ struct Document {
         return refreshalways;
     }
 
-    void ScrollOrZoom(wxDC &dc, bool zoomiftiny = false) {
+    void ScrollOrZoom(bool zoomiftiny = false) {
         if (!selected.g) return;
         auto drawroot = WalkPath(drawpath);
         // If we jumped to a cell which may be insided a folded cell, we have to unfold it
@@ -1491,14 +1491,14 @@ struct Document {
                 } else {
                     selected.SelAll();
                 }
-                ScrollOrZoom(dc);
+                ScrollOrZoom();
                 return nullptr;
 
             case A_NEWGRID:
                 if (!(c = selected.ThinExpand(this))) return OneCell();
                 if (c->grid) {
                     SetSelect(Selection(c->grid, 0, c->grid->ys, 1, 0));
-                    ScrollOrZoom(dc, true);
+                    ScrollOrZoom(true);
                 } else {
                     c->AddUndo(this);
                     c->AddGrid();
@@ -1884,7 +1884,7 @@ struct Document {
             case A_ENTERGRID:
                 if (!c->grid) Action(A_NEWGRID);
                 SetSelect(Selection(c->grid, 0, 0, 1, 1));
-                ScrollOrZoom(dc, true);
+                ScrollOrZoom(true);
                 return nullptr;
 
             case A_LINK:
@@ -1901,7 +1901,7 @@ struct Document {
                                        k == A_LINKIMG || k == A_LINKIMGREV);
                 if (!link || !link->parent) return _(L"No matching cell found!");
                 SetSelect(link->parent->grid->FindCell(link));
-                ScrollOrZoom(dc, true);
+                ScrollOrZoom(true);
                 return nullptr;
             }
 
@@ -1934,7 +1934,7 @@ struct Document {
                 if (!next) return _(L"No matches for filter.");
                 if (next->parent) SetSelect(next->parent->grid->FindCell(next));
                 sw->SetFocus();
-                ScrollOrZoom(dc, true);
+                ScrollOrZoom(true);
                 return nullptr;
         }
 
@@ -1991,7 +1991,7 @@ struct Document {
         if (!jump) return nullptr;
         SetSelect(next->parent->grid->FindCell(next));
         if (focusmatch) sw->SetFocus();
-        ScrollOrZoom(dc, true);
+        ScrollOrZoom(true);
         return nullptr;
     }
 
@@ -2204,7 +2204,7 @@ struct Document {
             undolistsizeatfullsave = -1;  // gone beyond the save point, always modified
         modified = undolistsizeatfullsave != undolist.size();
         if (selected.g)
-            ScrollOrZoom(dc);
+            ScrollOrZoom();
         else
             Refresh();
         UpdateFileName();

--- a/src/document.h
+++ b/src/document.h
@@ -222,7 +222,7 @@ struct Document {
                     bool cursoronly = false) {
         sys->UpdateAmountStatus(sel);
         if (refreshinstead) {
-            Refresh();
+            sw->Refresh();
             return;
         }
         if (!sel.g) return;
@@ -233,7 +233,7 @@ struct Document {
     void RefreshMove(Selection &sel) {
         sys->UpdateAmountStatus(sel);
         scrolltoselection = true;
-        Refresh();
+        sw->Refresh();
     }
 
     void UpdateHover(wxDC &dc) {
@@ -271,12 +271,12 @@ struct Document {
                                           ? r.y + r.height - canvash + wxSYS_HSCROLL_Y
                                           : cury,
                                       true);
-                    if (needslayout) Refresh();
+                    if (needslayout) sw->Refresh();
                     return true;
                 }
             }
         }
-        if (refreshalways) Refresh();
+        if (refreshalways) sw->Refresh();
         return refreshalways;
     }
 
@@ -351,7 +351,7 @@ struct Document {
             hover = tc_parent ? tc_parent->grid->FindCell(tc) : Selection();
             SetSelect(hover);
         }
-        Refresh();
+        sw->Refresh();
     }
 
     auto CopyEntireCells(wxString &s, int k) {
@@ -442,13 +442,13 @@ struct Document {
         if (begindrag.Thin() || selected.Thin()) {
             SetSelect(hover);
             ResetCursor();
-            Refresh();
+            sw->Refresh();
         } else {
             auto old = selected;
             selected.Merge(begindrag, hover);
             if (!(old == selected)) {
                 ResetCursor();
-                Refresh();
+                sw->Refresh();
             }
         }
         return;
@@ -666,17 +666,10 @@ struct Document {
         laststylebits = -1;
     }
 
-    void Refresh() {
-        if (sw) {
-            sw->Refresh(false);
-            sw->Update();
-        }
-    }
-
     void ClearSelectionRefresh() {
         selected.g = nullptr;
         begindrag.g = nullptr;
-        Refresh();
+        sw->Refresh();
     }
 
     bool CheckForChanges() {
@@ -713,7 +706,7 @@ struct Document {
         if (!selected.g) return nullptr;
         if (selected.Thin()) {
             selected.SelAll();
-            Refresh();
+            sw->Refresh();
         } else if (auto c = selected.GetCell()) {
             if (selected.TextEdit()) {
                 c->text.SelectWord(selected);
@@ -721,7 +714,7 @@ struct Document {
             } else {
                 selected.EnterEditOnly(this);
             }
-            Refresh();
+            sw->Refresh();
         }
         return nullptr;
     }
@@ -759,7 +752,7 @@ struct Document {
         auto root = currentview ? curdrawroot : rootgrid;
         if (k == A_EXPIMAGE) {
             auto bm = GetBitmap();
-            Refresh();
+            sw->Refresh();
             if (!bm.SaveFile(fn, wxBITMAP_TYPE_PNG)) return _(L"Error writing PNG file!");
         } else {
             wxFFileOutputStream fos(fn, L"w+b");
@@ -994,7 +987,7 @@ struct Document {
                                                _(L"size:"), _(L"New Sheet"), 10, 1, 25, sys->frame);
                 if (size < 0) return _(L"New file cancelled.");
                 sys->InitDB(size);
-                sys->frame->GetCurTab()->doc->Refresh();
+                sys->frame->GetCurTab()->Refresh();
                 return nullptr;
             }
 
@@ -1049,7 +1042,7 @@ struct Document {
                     sys->cfg->Write(L"defaultfontsize", g_deftextsize);
                     // rootgrid->ResetChildren();
                     sys->frame->TabsReset();  // ResetChildren on all
-                    Refresh();
+                    sw->Refresh();
                 }
                 return nullptr;
             }
@@ -1103,7 +1096,7 @@ struct Document {
                         if (c->cellcolor == oldbg && (!c->parent || c->parent->cellcolor == color))
                             c->cellcolor = color;
                     }
-                    Refresh();
+                    sw->Refresh();
                 }
                 return nullptr;
             }
@@ -1111,7 +1104,7 @@ struct Document {
             case A_DEFCURCOL: {
                 if (auto color = PickColor(sys->frame, sys->cursorcolor); color != (uint)-1) {
                     sys->cfg->Write(L"cursorcolor", sys->cursorcolor = color);
-                    Refresh();
+                    sw->Refresh();
                 }
                 return nullptr;
             }
@@ -1137,7 +1130,7 @@ struct Document {
                                         ? sys->frame->filter->GetValue()
                                         : sys->frame->filter->GetValue().Lower();
                 auto msg = this->SearchNext(false, false, false);
-                this->Refresh();
+                sw->Refresh();
                 return msg;
             }
 
@@ -1149,7 +1142,7 @@ struct Document {
             case A_ROUND5:
             case A_ROUND6:
                 sys->cfg->Write(L"roundness", long(sys->roundness = k - A_ROUND0));
-                Refresh();
+                sw->Refresh();
                 return nullptr;
 
             case A_OPENCELLCOLOR:
@@ -1176,7 +1169,7 @@ struct Document {
                     rootgrid->AddUndo(this);  // expensive?
                     rootgrid->FindReplaceAll(replaces, lreplaces);
                     rootgrid->ResetChildren();
-                    Refresh();
+                    sw->Refresh();
                 } else {
                     loopallcellssel(c, true) if (c->text.IsInSearch()) c->AddUndo(this);
                     selected.g->ReplaceStr(this, replaces, lreplaces, selected);
@@ -1200,7 +1193,7 @@ struct Document {
             case A_SCALED:
                 scaledviewingmode = !scaledviewingmode;
                 rootgrid->ResetChildren();
-                Refresh();
+                sw->Refresh();
                 return scaledviewingmode ? _(L"Now viewing TreeSheet to fit to the screen exactly, press F12 to return to normal.")
                                          : _(L"1:1 scale restored.");
 
@@ -1288,7 +1281,7 @@ struct Document {
                     if (selected.cursorend == 0) return nullptr;
                     c->AddUndo(this);
                     c->text.Backspace(selected);
-                    Refresh();
+                    sw->Refresh();
                 } else {
                     selected.g->MultiCellDelete(this, selected);
                     SetSelect(selected);
@@ -1308,7 +1301,7 @@ struct Document {
                     if (selected.cursor == c->text.t.Len()) return nullptr;
                     c->AddUndo(this);
                     c->text.Delete(selected);
-                    Refresh();
+                    sw->Refresh();
                 } else {
                     selected.g->MultiCellDelete(this, selected);
                     SetSelect(selected);
@@ -1321,7 +1314,7 @@ struct Document {
                     if (selected.cursor == c->text.t.Len()) return nullptr;
                     c->AddUndo(this);
                     c->text.DeleteWord(selected);
-                    Refresh();
+                    sw->Refresh();
                 }
                 ZoomOutIfNoGrid();
                 return nullptr;
@@ -1344,7 +1337,7 @@ struct Document {
                         c->AddUndo(this);
                         c->text.Backspace(selected);
                     }
-                    Refresh();
+                    sw->Refresh();
                 }
                 ZoomOutIfNoGrid();
                 return nullptr;
@@ -1375,13 +1368,13 @@ struct Document {
                 selected.g->MultiCellDeleteSub(this, deletesel);
                 SetSelect(Selection(selected.g, selected.x, selected.y, 1, 1));
                 fc->ResetLayout();
-                Refresh();
+                sw->Refresh();
                 return nullptr;
             }
 
             case wxID_SELECTALL:
                 selected.SelAll();
-                Refresh();
+                sw->Refresh();
                 return nullptr;
 
             case A_UP:
@@ -1404,12 +1397,12 @@ struct Document {
                 if (!selected.TextEdit() && k == A_SCLEFT) {
                     selected.xs = selected.Thin() ? selected.x : selected.x + 1;
                     selected.x = 0;
-                    Refresh();
+                    sw->Refresh();
                     return nullptr;
                 }
                 if (!selected.TextEdit() && k == A_SCRIGHT) {
                     selected.xs = selected.g->xs - selected.x;
-                    Refresh();
+                    sw->Refresh();
                     return nullptr;
                 }
                 selected.Cursor(this, k - A_SCUP + A_UP, true, true);
@@ -1420,11 +1413,11 @@ struct Document {
                 if (!selected.TextEdit() && k == A_SCUP) {
                     selected.ys = selected.Thin() ? selected.y : selected.y + 1;
                     selected.y = 0;
-                    Refresh();
+                    sw->Refresh();
                 }
                 if (!selected.TextEdit() && k == A_SCDOWN) {
                     selected.ys = selected.g->ys - selected.y;
-                    Refresh();
+                    sw->Refresh();
                 }
                 return nullptr;
 
@@ -1457,7 +1450,7 @@ struct Document {
                 loopallcellssel(c, false) {
                     c->celltype =
                         (newcelltype == CT_CODE) ? sys->ev.InferCellType(c->text) : newcelltype;
-                    Refresh();
+                    sw->Refresh();
                 }
                 return nullptr;
             }
@@ -1505,7 +1498,7 @@ struct Document {
                     wxTheClipboard->Close();
                 } else if (sys->cellclipboard) {
                     c->Paste(this, sys->cellclipboard.get(), selected);
-                    Refresh();
+                    sw->Refresh();
                 }
                 return nullptr;
 
@@ -1514,7 +1507,7 @@ struct Document {
                 selected.g->cell->AddUndo(this);
                 selected.g->SetStyles(selected, sys->cellclipboard.get());
                 selected.g->cell->ResetChildren();
-                Refresh();
+                sw->Refresh();
                 return nullptr;
 
             case A_ENTERCELL:
@@ -1540,7 +1533,7 @@ struct Document {
                                      wxFD_OPEN | wxFD_FILE_MUST_EXIST | wxFD_CHANGE_DIR);
                 c->AddUndo(this);
                 LoadImageIntoCell(fn, c, sys->frame->FromDIP(1.0));
-                Refresh();
+                sw->Refresh();
                 return nullptr;
             }
 
@@ -1548,7 +1541,7 @@ struct Document {
                 selected.g->cell->AddUndo(this);
                 selected.g->ClearImages(selected);
                 selected.g->cell->ResetChildren();
-                Refresh();
+                sw->Refresh();
                 return nullptr;
             }
 
@@ -1558,13 +1551,13 @@ struct Document {
             case A_SCOLS:
                 selected.y = 0;
                 selected.ys = selected.g->ys;
-                Refresh();
+                sw->Refresh();
                 return nullptr;
 
             case A_SROWS:
                 selected.x = 0;
                 selected.xs = selected.g->xs;
-                Refresh();
+                sw->Refresh();
                 return nullptr;
 
             case A_BORD0:
@@ -1576,7 +1569,7 @@ struct Document {
                 selected.g->cell->AddUndo(this);
                 selected.g->SetBorder(k - A_BORD0 + 1, selected);
                 selected.g->cell->ResetChildren();
-                Refresh();
+                sw->Refresh();
                 return nullptr;
 
             case A_TEXTGRID: return layrender(-1, true, true);
@@ -1623,7 +1616,7 @@ struct Document {
                         break;
                 }
                 selected.g->cell->ResetChildren();
-                Refresh();
+                sw->Refresh();
                 return nullptr;
 
             case A_MINISIZE: {
@@ -1640,7 +1633,7 @@ struct Document {
                 }
                 outer.clear();
                 selected.g->cell->ResetChildren();
-                Refresh();
+                sw->Refresh();
                 return nullptr;
             }
 
@@ -1652,7 +1645,7 @@ struct Document {
                     c->grid->folded = k == A_FOLD ? !c->grid->folded : k == A_FOLDALL;
                     c->ResetChildren();
                 }
-                Refresh();
+                sw->Refresh();
                 return nullptr;
 
             case A_HOME:
@@ -1693,7 +1686,7 @@ struct Document {
                 }
                 curdrawroot->ResetChildren();
                 curdrawroot->ResetLayout();
-                Refresh();
+                sw->Refresh();
                 return nullptr;
             }
 
@@ -1703,7 +1696,7 @@ struct Document {
                 }
                 curdrawroot->ResetChildren();
                 curdrawroot->ResetLayout();
-                Refresh();
+                sw->Refresh();
                 return nullptr;
             }
 
@@ -1799,13 +1792,13 @@ struct Document {
                     if (!c->text.t.Len()) continue;
                     tags[c->text.t] = g_tagcolor_default;
                 }
-                Refresh();
+                sw->Refresh();
                 return nullptr;
             }
 
             case A_TAGREMOVE: {
                 loopallcellssel(c, false) tags.erase(c->text.t);
-                Refresh();
+                sw->Refresh();
                 return nullptr;
             }
         }
@@ -1819,7 +1812,7 @@ struct Document {
                         ac->grid->Transpose();
                         ac->ResetChildren();
                         SetSelect(ac->parent ? ac->parent->grid->FindCell(ac) : Selection());
-                        Refresh();
+                        sw->Refresh();
                         return nullptr;
                     } else
                         return NoGrid();
@@ -1896,14 +1889,14 @@ struct Document {
                 SetSelect(pp->grid->HierarchySwap(c->text.t));
                 pp->ResetChildren();
                 pp->ResetLayout();
-                Refresh();
+                sw->Refresh();
                 return nullptr;
             }
 
             case A_FILTERBYCELLBG:
                 loopallcells(ci) ci->text.filtered = ci->cellcolor != c->cellcolor;
                 rootgrid->ResetChildren();
-                Refresh();
+                sw->Refresh();
                 return nullptr;
 
             case A_FILTERMATCHNEXT:
@@ -1923,7 +1916,7 @@ struct Document {
                 if (LastUndoSameCellTextEdit(c))
                     Undo(undolist, redolist);
                 else
-                    Refresh();
+                    sw->Refresh();
                 selected.ExitEdit(this);
                 return nullptr;
 
@@ -1931,7 +1924,7 @@ struct Document {
                 if (selected.cursorend == 0) return nullptr;
                 c->AddUndo(this);
                 c->text.BackspaceWord(selected);
-                Refresh();
+                sw->Refresh();
                 ZoomOutIfNoGrid();
                 return nullptr;
 
@@ -1980,7 +1973,7 @@ struct Document {
         if (ds >= 0 && selected.IsAll()) selected.g->cell->drawstyle = ds;
         selected.g->SetGridTextLayout(ds, v, noset, selected);
         selected.g->cell->ResetChildren();
-        Refresh();
+        sw->Refresh();
         return nullptr;
     }
 
@@ -2023,7 +2016,7 @@ struct Document {
             if (!c) return;
             c->AddUndo(this);
             if (!LoadImageIntoCell(as[0], c, sys->frame->FromDIP(1.0))) PasteSingleText(c, as[0]);
-            Refresh();
+            sw->Refresh();
             return;
         }
         if (c && (fmt == wxDF_TEXT || fmt == wxDF_UNICODETEXT)) {
@@ -2049,7 +2042,7 @@ struct Document {
                         }
                     }
                 }
-                Refresh();
+                sw->Refresh();
             }
             return;
         }
@@ -2061,7 +2054,7 @@ struct Document {
                 vector<uint8_t> data = ConvertWxImageToBuffer(im, wxBITMAP_TYPE_PNG);
                 SetImageBM(c, std::move(data), sys->frame->FromDIP(1.0));
                 c->Reset();
-                Refresh();
+                sw->Refresh();
             }
         }
     }
@@ -2072,7 +2065,7 @@ struct Document {
                 L"Can't sort: make a 1xN selection to indicate what column to sort on, and what rows to affect");
         selected.g->cell->AddUndo(this);
         selected.g->Sort(selected, descending);
-        Refresh();
+        sw->Refresh();
         return nullptr;
     }
 
@@ -2085,7 +2078,7 @@ struct Document {
                 selected.g->DeleteCells(dx, dy, nxs, nys);
                 v -= dec;
             }
-            Refresh();
+            sw->Refresh();
         }
     }
 
@@ -2184,7 +2177,7 @@ struct Document {
         if (selected.g)
             ScrollOrZoom();
         else
-            Refresh();
+            sw->Refresh();
         UpdateFileName();
     }
 
@@ -2217,7 +2210,7 @@ struct Document {
         if (!selected.g) return;
         selected.g->cell->AddUndo(this);
         loopallcellssel(c, false) LoadImageIntoCell(fn, c, sc);
-        Refresh();
+        sw->Refresh();
     }
 
     void RecreateTagMenu(wxMenu &menu) {
@@ -2239,7 +2232,7 @@ struct Document {
                 }
                 selected.g->cell->ResetChildren();
                 selected.g->cell->ResetLayout();
-                Refresh();
+                sw->Refresh();
                 return nullptr;
             }
         ASSERT(0);
@@ -2267,7 +2260,7 @@ struct Document {
         });
         loopv(i, itercells) itercells[i]->text.filtered = i > itercells.size() * editfilter / 100;
         rootgrid->ResetChildren();
-        Refresh();
+        sw->Refresh();
     }
 
     void ApplyEditRangeFilter(wxDateTime &rangebegin, wxDateTime &rangeend) {
@@ -2278,7 +2271,7 @@ struct Document {
             c->text.filtered = !c->text.lastedit.IsBetween(rangebegin, rangeend);
         }
         rootgrid->ResetChildren();
-        Refresh();
+        sw->Refresh();
     }
 
     wxDateTime ParseDateTimeString(const wxString &s) {
@@ -2293,6 +2286,6 @@ struct Document {
         scrolltoselection = true;
         loopallcells(c) c->text.filtered = on && !c->text.IsInSearch();
         rootgrid->ResetChildren();
-        Refresh();
+        sw->Refresh();
     }
 };

--- a/src/document.h
+++ b/src/document.h
@@ -78,7 +78,6 @@ struct Document {
     wxPrintData printData;
     wxPageSetupDialogData pageSetupData;
     uint printscale {0};
-    bool redrawpending {false};
     bool scrolltoselection {true};
     bool scaledviewingmode {false};
     bool updatehover {false};
@@ -572,7 +571,6 @@ struct Document {
     }
 
     void Draw(wxPaintDC &dc) {
-        redrawpending = false;
         dc.SetBackground(wxBrush(wxColor(Background())));
         dc.Clear();
         if (!rootgrid) return;
@@ -672,20 +670,8 @@ struct Document {
 
     void Refresh() {
         if (sw) {
-            hover.g = nullptr;
-            redrawpending = true;
-            sys->UpdateStatus(selected);
-            #ifdef SIMPLERENDER
-                // wxWidgets (wxGTK, wxMAC) does not always automatically update the scrollbar
-                // to new canvas size and current position within after zoom so force it manually
-                int curx, cury;
-                sw->GetViewStart(&curx, &cury);
-                sw->SetScrollbars(1, 1, layoutxs, layoutys, curx, cury, true);
-            #endif
-            sw->Refresh(false);
-            #ifdef __WXGTK__
-                sw->Update();
-            #endif
+            sw->Refresh();
+            sw->Update();
         }
     }
 

--- a/src/document.h
+++ b/src/document.h
@@ -221,15 +221,14 @@ struct Document {
         return _(L"");
     }
 
-    void DrawSelect(wxDC &dc, Selection &sel) {
-        sys->UpdateAmountStatus(sel);
-        if (!sel.g) return;
+    void DrawSelect(wxDC &dc, Selection &s) {
+        sys->UpdateStatus(s);
+        if (!s.g) return;
         ResetFont();
-        sel.g->DrawSelect(this, dc, sel);
+        s.g->DrawSelect(this, dc, s);
     }
 
-    void RefreshMove(Selection &sel) {
-        sys->UpdateAmountStatus(sel);
+    void RefreshMove(Selection &s) {
         scrolltoselection = true;
         sw->Refresh();
     }
@@ -477,7 +476,6 @@ struct Document {
                 selected.g->ResizeColWidths(dir, selected, hierarchical);
                 selected.g->cell->ResetLayout();
                 selected.g->cell->ResetChildren();
-                sys->UpdateStatus(selected);
                 RefreshMove(selected);
                 return dir > 0 ? _(L"Column width increased.") : _(L"Column width decreased.");
             }
@@ -487,7 +485,6 @@ struct Document {
             selected.g->cell->AddUndo(this);
             selected.g->ResetChildren();
             selected.g->RelSize(-dir, selected, pathscalebias);
-            sys->UpdateStatus(selected);
             RefreshMove(selected);
             return dir > 0 ? _(L"Text size increased.") : _(L"Text size decreased.");
         } else if (ctrl) {

--- a/src/document.h
+++ b/src/document.h
@@ -915,9 +915,6 @@ struct Document {
     }
 
     const wxChar *Action(int k) {
-        wxClientDC dc(sw);
-        sw->DoPrepareDC(dc);
-        ShiftToCenter(dc);
 
         switch (k) {
             case wxID_EXECUTE:
@@ -1132,7 +1129,7 @@ struct Document {
 
             case A_SEARCHNEXT:
             case A_SEARCHPREV: {
-                if (sys->searchstring.Len()) return SearchNext(dc, false, true, k == A_SEARCHPREV);
+                if (sys->searchstring.Len()) return SearchNext(false, true, k == A_SEARCHPREV);
                 if (auto c = selected.GetCell()) {
                     auto s = c->text.ToText(0, selected, A_EXPTEXT);
                     if (!s.Len()) return _(L"No text to search for.");
@@ -1150,7 +1147,7 @@ struct Document {
                 sys->searchstring = (sys->casesensitivesearch)
                                         ? sys->frame->filter->GetValue()
                                         : sys->frame->filter->GetValue().Lower();
-                auto msg = this->SearchNext(dc, false, false, false);
+                auto msg = this->SearchNext(false, false, false);
                 this->Refresh();
                 return msg;
             }
@@ -1194,7 +1191,7 @@ struct Document {
                 } else {
                     loopallcellssel(c, true) if (c->text.IsInSearch()) c->AddUndo(this);
                     selected.g->ReplaceStr(this, replaces, lreplaces, selected);
-                    if (k == A_REPLACEONCEJ) return SearchNext(dc, false, true, false);
+                    if (k == A_REPLACEONCEJ) return SearchNext(false, true, false);
                 }
                 return _(L"Text has been replaced.");
             }
@@ -1973,7 +1970,7 @@ struct Document {
         }
     }
 
-    const wxChar *SearchNext(wxDC &dc, bool focusmatch, bool jump, bool reverse) {
+    const wxChar *SearchNext(bool focusmatch, bool jump, bool reverse) {
         if (!rootgrid) return nullptr;  // fix crash when opening new doc
         if (!sys->searchstring.Len()) return _(L"No search string.");
         bool lastsel = true;

--- a/src/document.h
+++ b/src/document.h
@@ -1108,7 +1108,7 @@ struct Document {
                 sys->searchstring = (sys->casesensitivesearch)
                                         ? sys->frame->filter->GetValue()
                                         : sys->frame->filter->GetValue().Lower();
-                auto msg = this->SearchNext(false, false, false);
+                auto msg = SearchNext(false, false, false);
                 sw->Refresh();
                 return msg;
             }

--- a/src/document.h
+++ b/src/document.h
@@ -443,18 +443,17 @@ struct Document {
         if (hover.Thin()) return;
         ShiftToCenter(dc);
         if (begindrag.Thin() || selected.Thin()) {
-            DrawSelect(dc, selected);
             SetSelect(hover);
-            DrawSelect(dc, selected, true);
+            ResetCursor();
+            Refresh();
         } else {
             auto old = selected;
             selected.Merge(begindrag, hover);
             if (!(old == selected)) {
-                DrawSelect(dc, old);
-                DrawSelect(dc, selected, true);
+                ResetCursor();
+                Refresh();
             }
         }
-        ResetCursor();
         return;
     }
 

--- a/src/document.h
+++ b/src/document.h
@@ -1412,17 +1412,17 @@ struct Document {
             case A_UP:
             case A_DOWN:
             case A_LEFT:
-            case A_RIGHT: selected.Cursor(this, k, false, false, dc); return nullptr;
+            case A_RIGHT: selected.Cursor(this, k, false, false); return nullptr;
 
             case A_MUP:
             case A_MDOWN:
             case A_MLEFT:
-            case A_MRIGHT: selected.Cursor(this, k - A_MUP + A_UP, true, false, dc); return nullptr;
+            case A_MRIGHT: selected.Cursor(this, k - A_MUP + A_UP, true, false); return nullptr;
 
             case A_SUP:
             case A_SDOWN:
             case A_SLEFT:
-            case A_SRIGHT: selected.Cursor(this, k - A_SUP + A_UP, false, true, dc); return nullptr;
+            case A_SRIGHT: selected.Cursor(this, k - A_SUP + A_UP, false, true); return nullptr;
 
             case A_SCLEFT:
             case A_SCRIGHT:
@@ -1437,7 +1437,7 @@ struct Document {
                     Refresh();
                     return nullptr;
                 }
-                selected.Cursor(this, k - A_SCUP + A_UP, true, true, dc);
+                selected.Cursor(this, k - A_SCUP + A_UP, true, true);
                 return nullptr;
 
             case A_SCUP:
@@ -1547,7 +1547,7 @@ struct Document {
             case A_PROGRESSCELL: {
                 if (!(c = selected.ThinExpand(this))) return OneCell();
                 if (selected.TextEdit()) {
-                    selected.Cursor(this, (k == A_ENTERCELL ? A_DOWN : A_RIGHT), false, false, dc,
+                    selected.Cursor(this, (k == A_ENTERCELL ? A_DOWN : A_RIGHT), false, false, 
                                     true);
                 } else {
                     selected.EnterEdit(this,

--- a/src/document.h
+++ b/src/document.h
@@ -227,7 +227,7 @@ struct Document {
         s.g->DrawSelect(this, dc, s);
     }
 
-    void RefreshMove(Selection &s) {
+    void RefreshMove() {
         scrolltoselection = true;
         sw->Refresh();
     }
@@ -287,7 +287,7 @@ struct Document {
         for (auto cg = selected.g->cell; cg; cg = cg->parent)
             if (cg == drawroot) {
                 if (zoomiftiny) ZoomTiny();
-                RefreshMove(selected);
+                RefreshMove();
                 return;
             }
         Zoom(-100, false);
@@ -457,7 +457,7 @@ struct Document {
         }
         drawroot->ResetLayout();
         drawroot->ResetChildren();
-        RefreshMove(selected);
+        RefreshMove();
     }
 
     const wxChar *NoSel() { return _(L"This operation requires a selection."); }
@@ -474,7 +474,7 @@ struct Document {
                 selected.g->ResizeColWidths(dir, selected, hierarchical);
                 selected.g->cell->ResetLayout();
                 selected.g->cell->ResetChildren();
-                RefreshMove(selected);
+                RefreshMove();
                 return dir > 0 ? _(L"Column width increased.") : _(L"Column width decreased.");
             }
             return L"nothing to resize";
@@ -483,7 +483,7 @@ struct Document {
             selected.g->cell->AddUndo(this);
             selected.g->ResetChildren();
             selected.g->RelSize(-dir, selected, pathscalebias);
-            RefreshMove(selected);
+            RefreshMove();
             return dir > 0 ? _(L"Text size increased.") : _(L"Text size decreased.");
         } else if (ctrl) {
             int steps = abs(dir);
@@ -871,7 +871,7 @@ struct Document {
             c->AddUndo(this);  // FIXME: not needed for all keystrokes, or at least, merge all
                                // keystroke undos within same cell
             c->text.Key(this, uk, selected);
-            RefreshMove(selected);
+            RefreshMove();
             return nullptr;
         }
         unprocessed = true;
@@ -1453,7 +1453,7 @@ struct Document {
                     c->AddUndo(this);
                     c->AddGrid();
                     SetSelect(Selection(c->grid, 0, 0, 1, 1));
-                    RefreshMove(selected);
+                    RefreshMove();
                 }
                 return nullptr;
 
@@ -1500,7 +1500,7 @@ struct Document {
                     selected.EnterEdit(this,
                                        (k == A_ENTERCELL_JUMPTOEND) ? (int)c->text.t.Len() : 0,
                                        (int)c->text.t.Len());
-                    RefreshMove(selected);
+                    RefreshMove();
                 }
                 return nullptr;
             }
@@ -1924,7 +1924,7 @@ struct Document {
                     case A_HOME: c->text.HomeEnd(selected, true); break;
                     case A_END: c->text.HomeEnd(selected, false); break;
                 }
-                RefreshMove(selected);
+                RefreshMove();
                 return nullptr;
             }
             default: return _(L"Internal error: unimplemented operation!");

--- a/src/document.h
+++ b/src/document.h
@@ -587,6 +587,8 @@ struct Document {
                 if (!(clickright && hover.IsInside(selected))) {
                     if (selected.GetCell() == hover.GetCell() && hover.GetCell())
                         hover.EnterEditOnly(this);
+                    else
+                        hover.ExitEdit(this);
                     SetSelect(hover);
                     isctrlshiftdrag = clickisctrlshift;
                     scrolltoselection = true;

--- a/src/document.h
+++ b/src/document.h
@@ -936,7 +936,7 @@ struct Document {
 
             case wxID_UNDO:
                 if (undolist.size()) {
-                    Undo(dc, undolist, redolist);
+                    Undo(undolist, redolist);
                     return nullptr;
                 } else {
                     return _(L"Nothing more to undo.");
@@ -944,7 +944,7 @@ struct Document {
 
             case wxID_REDO:
                 if (redolist.size()) {
-                    Undo(dc, redolist, undolist, true);
+                    Undo(redolist, undolist, true);
                     return nullptr;
                 } else {
                     return _(L"Nothing more to redo.");
@@ -1943,7 +1943,7 @@ struct Document {
         switch (k) {
             case A_CANCELEDIT:
                 if (LastUndoSameCellTextEdit(c))
-                    Undo(dc, undolist, redolist);
+                    Undo(undolist, redolist);
                 else
                     Refresh();
                 selected.ExitEdit(this);
@@ -2179,7 +2179,7 @@ struct Document {
         undolistsizeatfullsave -= items_culled;  // Allowed to go < 0
     }
 
-    void Undo(wxDC &dc, auto &fromlist, auto &tolist, bool redo = false) {
+    void Undo(auto &fromlist, auto &tolist, bool redo = false) {
         auto beforesel = selected;
         vector<Selection> beforepath;
         if (beforesel.g) CreatePath(beforesel.g->cell, beforepath);

--- a/src/document.h
+++ b/src/document.h
@@ -544,7 +544,7 @@ struct Document {
                             curdrawroot->ColWidth(), 0);
     }
 
-    void Draw(wxPaintDC &dc) {
+    void Draw(wxDC &dc) {
         dc.SetBackground(wxBrush(wxColor(Background())));
         dc.Clear();
         if (!rootgrid) return;

--- a/src/document.h
+++ b/src/document.h
@@ -325,7 +325,6 @@ struct Document {
     void Select(wxDC &dc, bool right, int isctrlshift) {
         begindrag = Selection();
         if (right && hover.IsInside(selected)) return;
-        ShiftToCenter(dc);
         if (selected.GetCell() == hover.GetCell() && hover.GetCell()) hover.EnterEditOnly(this);
         SetSelect(hover);
         isctrlshiftdrag = isctrlshift;
@@ -440,8 +439,7 @@ struct Document {
             begindrag = hover;
             return;
         }
-        if (hover.Thin()) return;
-        ShiftToCenter(dc);
+        if (hover.Thin()) return;;
         if (begindrag.Thin() || selected.Thin()) {
             SetSelect(hover);
             ResetCursor();
@@ -493,7 +491,6 @@ struct Document {
     const wxChar *Wheel(wxDC &dc, int dir, bool alt, bool ctrl, bool shift,
                         bool hierarchical = true) {
         if (!dir) return nullptr;
-        ShiftToCenter(dc);
         if (alt) {
             if (!selected.g) return NoSel();
             if (selected.xs > 0) {
@@ -725,7 +722,6 @@ struct Document {
 
     const wxChar *DoubleClick(wxDC &dc) {
         if (!selected.g) return nullptr;
-        ShiftToCenter(dc);
         if (selected.Thin()) {
             selected.SelAll();
             Refresh();

--- a/src/document.h
+++ b/src/document.h
@@ -488,7 +488,7 @@ struct Document {
     const wxChar *NoThin() { return _(L"This operation doesn't work on thin selections."); }
     const wxChar *NoGrid() { return _(L"This operation requires a cell that contains a grid."); }
 
-    const wxChar *Wheel(wxDC &dc, int dir, bool alt, bool ctrl, bool shift,
+    const wxChar *Wheel(int dir, bool alt, bool ctrl, bool shift,
                         bool hierarchical = true) {
         if (!dir) return nullptr;
         if (alt) {
@@ -906,10 +906,8 @@ struct Document {
             }
             c->AddUndo(this);  // FIXME: not needed for all keystrokes, or at least, merge all
                                // keystroke undos within same cell
-            wxClientDC dc(sw);
-            ShiftToCenter(dc);
             c->text.Key(this, uk, selected);
-            ScrollIfSelectionOutOfView(dc, selected, true);
+            RefreshMove(selected);
             return nullptr;
         }
         unprocessed = true;
@@ -1039,17 +1037,17 @@ struct Document {
                 return nullptr;
 
             case A_ZOOMIN:
-                return Wheel(dc, 1, false, true,
+                return Wheel(1, false, true,
                              false);  // Zoom( 1, dc); return "zoomed in (menu)";
             case A_ZOOMOUT:
-                return Wheel(dc, -1, false, true,
+                return Wheel(-1, false, true,
                              false);  // Zoom(-1, dc); return "zoomed out (menu)";
-            case A_INCSIZE: return Wheel(dc, 1, false, false, true);
-            case A_DECSIZE: return Wheel(dc, -1, false, false, true);
-            case A_INCWIDTH: return Wheel(dc, 1, true, false, false);
-            case A_DECWIDTH: return Wheel(dc, -1, true, false, false);
-            case A_INCWIDTHNH: return Wheel(dc, 1, true, false, false, false);
-            case A_DECWIDTHNH: return Wheel(dc, -1, true, false, false, false);
+            case A_INCSIZE: return Wheel(1, false, false, true);
+            case A_DECSIZE: return Wheel( -1, false, false, true);
+            case A_INCWIDTH: return Wheel(1, true, false, false);
+            case A_DECWIDTH: return Wheel(-1, true, false, false);
+            case A_INCWIDTHNH: return Wheel(1, true, false, false, false);
+            case A_DECWIDTHNH: return Wheel(-1, true, false, false, false);
 
             case wxID_SELECT_FONT: {
                 wxFontData fdat;

--- a/src/document.h
+++ b/src/document.h
@@ -221,12 +221,10 @@ struct Document {
     void DrawSelect(wxDC &dc, Selection &sel, bool refreshinstead = false,
                     bool cursoronly = false) {
         sys->UpdateAmountStatus(sel);
-        #ifdef SIMPLERENDER
         if (refreshinstead) {
             Refresh();
             return;
         }
-        #endif
         if (!sel.g) return;
         ResetFont();
         sel.g->DrawSelect(this, dc, sel, cursoronly);
@@ -670,7 +668,7 @@ struct Document {
 
     void Refresh() {
         if (sw) {
-            sw->Refresh();
+            sw->Refresh(false);
             sw->Update();
         }
     }
@@ -1110,7 +1108,6 @@ struct Document {
                 return nullptr;
             }
 
-            #ifdef SIMPLERENDER
             case A_DEFCURCOL: {
                 if (auto color = PickColor(sys->frame, sys->cursorcolor); color != (uint)-1) {
                     sys->cfg->Write(L"cursorcolor", sys->cursorcolor = color);
@@ -1118,7 +1115,6 @@ struct Document {
                 }
                 return nullptr;
             }
-            #endif
 
             case A_SEARCHNEXT:
             case A_SEARCHPREV: {

--- a/src/document.h
+++ b/src/document.h
@@ -221,7 +221,7 @@ struct Document {
     }
 
     void DrawSelect(wxDC &dc, Selection &s) {
-        sys->UpdateStatus(s);
+        sys->frame->UpdateStatus(s);
         if (!s.g) return;
         ResetFont();
         s.g->DrawSelect(this, dc, s);
@@ -242,7 +242,6 @@ struct Document {
             drawroot->grid->FindXY(
                 this, x / currentviewscale - centerx / currentviewscale - hierarchysize,
                 y / currentviewscale - centery / currentviewscale - hierarchysize, dc);
-        sys->UpdateStatus(hover);
     }
 
     void ScrollIfSelectionOutOfView(wxDC &dc, Selection &sel) {

--- a/src/document.h
+++ b/src/document.h
@@ -596,7 +596,6 @@ struct Document {
                       : 0;
         sw->DoPrepareDC(dc);
         ShiftToCenter(dc);
-        Render(dc);
         if (selectclick || updatehover) {
             UpdateHover(dc);
             if (selectclick) {
@@ -610,6 +609,7 @@ struct Document {
             }
             selectclick = clickright = clickisctrlshift = updatehover = false;
         }
+        Render(dc);
         DrawSelect(dc, selected);
         if (scrolltoselection) {
             ScrollIfSelectionOutOfView(dc, selected, false, false);

--- a/src/document.h
+++ b/src/document.h
@@ -267,6 +267,8 @@ struct Document {
                                           ? r.y + r.height - canvash + wxSYS_HSCROLL_Y
                                           : cury,
                                       true);
+                    sw->Refresh();
+                    sw->Update();
                 }
             }
         }

--- a/src/document.h
+++ b/src/document.h
@@ -1307,7 +1307,7 @@ struct Document {
                     selected.g->MultiCellDelete(this, selected);
                     SetSelect(selected);
                 }
-                ZoomOutIfNoGrid(dc);
+                ZoomOutIfNoGrid();
                 return nullptr;
 
             case A_DELETE:
@@ -1327,7 +1327,7 @@ struct Document {
                     selected.g->MultiCellDelete(this, selected);
                     SetSelect(selected);
                 }
-                ZoomOutIfNoGrid(dc);
+                ZoomOutIfNoGrid();
                 return nullptr;
 
             case A_DELETE_WORD:
@@ -1337,7 +1337,7 @@ struct Document {
                     c->text.DeleteWord(selected);
                     Refresh();
                 }
-                ZoomOutIfNoGrid(dc);
+                ZoomOutIfNoGrid();
                 return nullptr;
 
             case wxID_CUT:
@@ -1360,7 +1360,7 @@ struct Document {
                     }
                     Refresh();
                 }
-                ZoomOutIfNoGrid(dc);
+                ZoomOutIfNoGrid();
                 return nullptr;
 
             case A_COPYBM:
@@ -1946,7 +1946,7 @@ struct Document {
                 c->AddUndo(this);
                 c->text.BackspaceWord(selected);
                 Refresh();
-                ZoomOutIfNoGrid(dc);
+                ZoomOutIfNoGrid();
                 return nullptr;
 
             case A_SHOME:
@@ -1998,7 +1998,7 @@ struct Document {
         return nullptr;
     }
 
-    void ZoomOutIfNoGrid(wxDC &dc) {
+    void ZoomOutIfNoGrid() {
         if (!WalkPath(drawpath)->grid) Zoom(-1);
     }
 

--- a/src/document.h
+++ b/src/document.h
@@ -324,7 +324,7 @@ struct Document {
         begindrag = sel;
     }
 
-    void Select(wxDC &dc, bool right, int isctrlshift) {
+    void Select(bool right, int isctrlshift) {
         begindrag = Selection();
         if (right && hover.IsInside(selected)) return;
         if (selected.GetCell() == hover.GetCell() && hover.GetCell()) hover.EnterEditOnly(this);
@@ -435,7 +435,7 @@ struct Document {
         return;
     }
 
-    void Drag(wxDC &dc) {
+    void Drag() {
         if (!selected.g || !hover.g || !begindrag.g) return;
         if (isctrlshiftdrag) {
             begindrag = hover;

--- a/src/document.h
+++ b/src/document.h
@@ -295,7 +295,6 @@ struct Document {
             }
         Zoom(-100, false);
         if (zoomiftiny) ZoomTiny();
-        RefreshMove(selected);
     }
 
     void ZoomTiny() {

--- a/src/document.h
+++ b/src/document.h
@@ -288,14 +288,14 @@ struct Document {
                 RefreshMove(selected);
                 return;
             }
-        Zoom(-100, dc, false);
+        Zoom(-100, false);
         if (zoomiftiny) ZoomTiny(dc);
         RefreshMove(selected);
     }
 
     void ZoomTiny(wxDC &dc) {
         if (auto c = selected.GetCell(); c && c->tiny) {
-            Zoom(1, dc);  // seems to leave selection box in a weird location?
+            Zoom(1);  // seems to leave selection box in a weird location?
             if (selected.GetCell() != c) ZoomTiny(dc);
         }
     }
@@ -473,7 +473,7 @@ struct Document {
             drawpath.erase(drawpath.begin(), drawpath.begin() + diff);
     }
 
-    void Zoom(int dir, wxDC &dc, bool fromroot = false) {
+    void Zoom(int dir, bool fromroot = false) {
         ZoomSetDrawPath(dir, fromroot);
         auto drawroot = WalkPath(drawpath);
         if (selected.GetCell() == drawroot && drawroot->grid) {
@@ -519,7 +519,7 @@ struct Document {
         } else if (ctrl) {
             int steps = abs(dir);
             dir = sign(dir);
-            loop(i, steps) Zoom(dir, dc);
+            loop(i, steps) Zoom(dir);
             return dir > 0 ? _(L"Zoomed in.") : _(L"Zoomed out.");
         } else {
             ASSERT(0);
@@ -2007,7 +2007,7 @@ struct Document {
     }
 
     void ZoomOutIfNoGrid(wxDC &dc) {
-        if (!WalkPath(drawpath)->grid) Zoom(-1, dc);
+        if (!WalkPath(drawpath)->grid) Zoom(-1);
     }
 
     void PasteSingleText(Cell *c, const wxString &s) { c->text.Insert(this, s, selected, false); }

--- a/src/document.h
+++ b/src/document.h
@@ -241,8 +241,9 @@ struct Document {
         hover = Selection();
         auto drawroot = WalkPath(drawpath);
         if (drawroot->grid)
-            drawroot->grid->FindXY(this, x / currentviewscale - centerx / currentviewscale - hierarchysize,
-                               y / currentviewscale - centery / currentviewscale - hierarchysize, dc);
+            drawroot->grid->FindXY(
+                this, x / currentviewscale - centerx / currentviewscale - hierarchysize,
+                y / currentviewscale - centery / currentviewscale - hierarchysize, dc);
         sys->UpdateStatus(hover);
     }
 
@@ -270,7 +271,6 @@ struct Document {
                 }
             }
         }
-
     }
 
     void ScrollOrZoom(bool zoomiftiny = false) {
@@ -419,7 +419,7 @@ struct Document {
             begindrag = hover;
             return;
         }
-        if (hover.Thin()) return;;
+        if (hover.Thin()) return;
         if (begindrag.Thin() || selected.Thin()) {
             SetSelect(hover);
             ResetCursor();
@@ -468,8 +468,7 @@ struct Document {
     const wxChar *NoThin() { return _(L"This operation doesn't work on thin selections."); }
     const wxChar *NoGrid() { return _(L"This operation requires a cell that contains a grid."); }
 
-    const wxChar *Wheel(int dir, bool alt, bool ctrl, bool shift,
-                        bool hierarchical = true) {
+    const wxChar *Wheel(int dir, bool alt, bool ctrl, bool shift, bool hierarchical = true) {
         if (!dir) return nullptr;
         if (alt) {
             if (!selected.g) return NoSel();
@@ -595,7 +594,8 @@ struct Document {
             if (selectclick) {
                 begindrag = Selection();
                 if (!(clickright && hover.IsInside(selected))) {
-                    if (selected.GetCell() == hover.GetCell() && hover.GetCell()) hover.EnterEditOnly(this);
+                    if (selected.GetCell() == hover.GetCell() && hover.GetCell())
+                        hover.EnterEditOnly(this);
                     SetSelect(hover);
                     isctrlshiftdrag = clickisctrlshift;
                     scrolltoselection = true;
@@ -888,7 +888,6 @@ struct Document {
     }
 
     const wxChar *Action(int k) {
-
         switch (k) {
             case wxID_EXECUTE:
                 sys->ev.Eval(rootgrid);
@@ -1013,7 +1012,7 @@ struct Document {
                 return Wheel(-1, false, true,
                              false);  // Zoom(-1, dc); return "zoomed out (menu)";
             case A_INCSIZE: return Wheel(1, false, false, true);
-            case A_DECSIZE: return Wheel( -1, false, false, true);
+            case A_DECSIZE: return Wheel(-1, false, false, true);
             case A_INCWIDTH: return Wheel(1, true, false, false);
             case A_DECWIDTH: return Wheel(-1, true, false, false);
             case A_INCWIDTHNH: return Wheel(1, true, false, false, false);
@@ -1504,7 +1503,7 @@ struct Document {
             case A_PROGRESSCELL: {
                 if (!(c = selected.ThinExpand(this))) return OneCell();
                 if (selected.TextEdit()) {
-                    selected.Cursor(this, (k == A_ENTERCELL ? A_DOWN : A_RIGHT), false, false, 
+                    selected.Cursor(this, (k == A_ENTERCELL ? A_DOWN : A_RIGHT), false, false,
                                     true);
                 } else {
                     selected.EnterEdit(this,

--- a/src/document.h
+++ b/src/document.h
@@ -731,14 +731,13 @@ struct Document {
             selected.SelAll();
             Refresh();
         } else if (auto c = selected.GetCell()) {
-            DrawSelect(dc, selected);
             if (selected.TextEdit()) {
                 c->text.SelectWord(selected);
                 begindrag = selected;
             } else {
                 selected.EnterEditOnly(this);
             }
-            DrawSelect(dc, selected, true);
+            Refresh();
         }
         return nullptr;
     }

--- a/src/document.h
+++ b/src/document.h
@@ -1685,7 +1685,7 @@ struct Document {
             case A_CHOME:
             case A_CEND:
                 if (selected.TextEdit()) break;
-                selected.HomeEnd(this, dc, k == A_HOME || k == A_CHOME);
+                selected.HomeEnd(this, k == A_HOME || k == A_CHOME);
                 return nullptr;
 
             case A_IMAGESCP:
@@ -1881,8 +1881,8 @@ struct Document {
         if (!c) return OneCell();
 
         switch (k) {
-            case A_NEXT: selected.Next(this, dc, false); return nullptr;
-            case A_PREV: selected.Next(this, dc, true); return nullptr;
+            case A_NEXT: selected.Next(this, false); return nullptr;
+            case A_PREV: selected.Next(this, true); return nullptr;
 
             case A_ENTERGRID:
                 if (!c->grid) Action(A_NEWGRID);

--- a/src/document.h
+++ b/src/document.h
@@ -596,15 +596,13 @@ struct Document {
                 }
             }
             if (doubleclick) {
+                SetSelect(hover);
                 if (selected.Thin()) {
                     selected.SelAll();
-                } else if (auto c = selected.GetCell()) {
-                    if (selected.TextEdit()) {
-                        c->text.SelectWord(selected);
-                        begindrag = selected;
-                    } else {
-                        selected.EnterEditOnly(this);
-                    }
+                } else if (Cell *c = selected.GetCell()) {
+                    selected.EnterEditOnly(this);
+                    c->text.SelectWord(selected);
+                    begindrag = selected;
                 }
             }
             updatehover = selectclick = clickright = clickisctrlshift = doubleclick = false;

--- a/src/document.h
+++ b/src/document.h
@@ -718,7 +718,7 @@ struct Document {
         return keep;
     }
 
-    const wxChar *DoubleClick(wxDC &dc) {
+    const wxChar *DoubleClick() {
         if (!selected.g) return nullptr;
         if (selected.Thin()) {
             selected.SelAll();

--- a/src/document.h
+++ b/src/document.h
@@ -326,7 +326,6 @@ struct Document {
         begindrag = Selection();
         if (right && hover.IsInside(selected)) return;
         ShiftToCenter(dc);
-        DrawSelect(dc, selected);
         if (selected.GetCell() == hover.GetCell() && hover.GetCell()) hover.EnterEditOnly(this);
         SetSelect(hover);
         isctrlshiftdrag = isctrlshift;

--- a/src/document.h
+++ b/src/document.h
@@ -284,19 +284,19 @@ struct Document {
         }
         for (auto cg = selected.g->cell; cg; cg = cg->parent)
             if (cg == drawroot) {
-                if (zoomiftiny) ZoomTiny(dc);
+                if (zoomiftiny) ZoomTiny();
                 RefreshMove(selected);
                 return;
             }
         Zoom(-100, false);
-        if (zoomiftiny) ZoomTiny(dc);
+        if (zoomiftiny) ZoomTiny();
         RefreshMove(selected);
     }
 
-    void ZoomTiny(wxDC &dc) {
+    void ZoomTiny() {
         if (auto c = selected.GetCell(); c && c->tiny) {
             Zoom(1);  // seems to leave selection box in a weird location?
-            if (selected.GetCell() != c) ZoomTiny(dc);
+            if (selected.GetCell() != c) ZoomTiny();
         }
     }
 

--- a/src/grid.h
+++ b/src/grid.h
@@ -440,7 +440,7 @@ struct Grid {
     void MultiCellDelete(Document *doc, Selection &sel) {
         cell->AddUndo(doc);
         MultiCellDeleteSub(doc, sel);
-        doc->Refresh();
+        doc->sw->Refresh();
     }
 
     void MultiCellDeleteSub(Document *doc, Selection &sel) {
@@ -672,21 +672,21 @@ struct Grid {
             c->text.stylebits ^= sb;
             c->text.WasEdited();
         }
-        doc->Refresh();
+        doc->sw->Refresh();
     }
 
     void ColorChange(Document *doc, int which, uint color, const Selection &sel) {
         cell->AddUndo(doc);
         cell->ResetChildren();
         foreachcellinsel(c, sel) c->ColorChange(doc, which, color);
-        doc->Refresh();
+        doc->sw->Refresh();
     }
 
     void ReplaceStr(Document *doc, const wxString &s, const wxString &ls, const Selection &sel) {
         cell->AddUndo(doc);
         cell->ResetChildren();
         foreachcellinsel(c, sel) c->text.ReplaceStr(s, ls);
-        doc->Refresh();
+        doc->sw->Refresh();
     }
 
     void CSVImport(const wxArrayString &as, wxString sep) {

--- a/src/grid.h
+++ b/src/grid.h
@@ -399,9 +399,6 @@ struct Grid {
     }
 
     void DrawSelect(Document *doc, wxDC &dc, Selection &sel, bool cursoronly) {
-        #ifndef SIMPLERENDER
-        dc.SetLogicalFunction(wxINVERT);
-        #endif
         if (sel.Thin()) {
             if (!cursoronly) DrawInsert(doc, dc, sel, 0);
         } else {
@@ -423,19 +420,9 @@ struct Grid {
                 dc.DrawRectangle(g.x + g.width - lw - 1, g.y + g.height - 2 + 2 * te, lw + 1,
                                  lw + 4 - 2 * te);
             }
-            #ifndef SIMPLERENDER
-            dc.SetLogicalFunction(wxXOR);
-            #endif
             if (sel.TextEdit())
-            #ifdef SIMPLERENDER
                 DrawCursor(doc, dc, sel, true, sys->cursorcolor, cursoronly);
-            #else
-                DrawCursor(doc, dc, sel, true, 0xFFFF, cursoronly);
-            #endif
         }
-        #ifndef SIMPLERENDER
-        dc.SetLogicalFunction(wxCOPY);
-        #endif
     }
 
     void DeleteCells(int dx, int dy, int nxs, int nys) {

--- a/src/grid.h
+++ b/src/grid.h
@@ -341,10 +341,9 @@ struct Grid {
         if (includefolded || !folded) foreachcell(c) c->ImageRefCount(includefolded);
     }
 
-    void DrawCursor(Document *doc, wxDC &dc, Selection &sel, bool full, uint color,
-                    bool cursoronly) {
+    void DrawCursor(Document *doc, wxDC &dc, Selection &sel, bool full, uint color) {
         if (auto c = sel.GetCell(); c && !c->tiny && (c->HasText() || !c->grid))
-            c->text.DrawCursor(doc, dc, sel, full, color, cursoronly, colwidths[sel.x]);
+            c->text.DrawCursor(doc, dc, sel, full, color, colwidths[sel.x]);
     }
 
     void DrawInsert(Document *doc, wxDC &dc, Selection &sel, uint colour) {
@@ -398,30 +397,28 @@ struct Grid {
         }
     }
 
-    void DrawSelect(Document *doc, wxDC &dc, Selection &sel, bool cursoronly) {
+    void DrawSelect(Document *doc, wxDC &dc, Selection &sel) {
         if (sel.Thin()) {
-            if (!cursoronly) DrawInsert(doc, dc, sel, 0);
+            DrawInsert(doc, dc, sel, 0);
         } else {
-            if (!cursoronly) {
-                dc.SetBrush(*wxBLACK_BRUSH);
-                dc.SetPen(*wxBLACK_PEN);
-                wxRect g = GetRect(doc, sel);
-                int lw = g_line_width;
-                int te = sel.TextEdit();
-                dc.DrawRectangle(g.x - 1 - lw, g.y - 1 - lw, g.width + 2 + 2 * lw, 2 + lw - te);
-                dc.DrawRectangle(g.x - 1 - lw, g.y - 1 + g.height + te, g.width + 2 + 2 * lw - 5,
-                                 2 + lw - te);
+            dc.SetBrush(*wxBLACK_BRUSH);
+            dc.SetPen(*wxBLACK_PEN);
+            wxRect g = GetRect(doc, sel);
+            int lw = g_line_width;
+            int te = sel.TextEdit();
+            dc.DrawRectangle(g.x - 1 - lw, g.y - 1 - lw, g.width + 2 + 2 * lw, 2 + lw - te);
+            dc.DrawRectangle(g.x - 1 - lw, g.y - 1 + g.height + te, g.width + 2 + 2 * lw - 5,
+                             2 + lw - te);
 
-                dc.DrawRectangle(g.x - 1 - lw, g.y + 1 - te, 2 + lw - te, g.height - 2 + 2 * te);
-                dc.DrawRectangle(g.x - 1 + g.width + te, g.y + 1 - te, 2 + lw - te,
-                                 g.height - 2 + 2 * te - 2 - te);
+            dc.DrawRectangle(g.x - 1 - lw, g.y + 1 - te, 2 + lw - te, g.height - 2 + 2 * te);
+            dc.DrawRectangle(g.x - 1 + g.width + te, g.y + 1 - te, 2 + lw - te,
+                             g.height - 2 + 2 * te - 2 - te);
 
-                dc.DrawRectangle(g.x + g.width, g.y + g.height - 2, lw + 2, lw + 4);
-                dc.DrawRectangle(g.x + g.width - lw - 1, g.y + g.height - 2 + 2 * te, lw + 1,
-                                 lw + 4 - 2 * te);
-            }
+            dc.DrawRectangle(g.x + g.width, g.y + g.height - 2, lw + 2, lw + 4);
+            dc.DrawRectangle(g.x + g.width - lw - 1, g.y + g.height - 2 + 2 * te, lw + 1,
+                             lw + 4 - 2 * te);
             if (sel.TextEdit())
-                DrawCursor(doc, dc, sel, true, sys->cursorcolor, cursoronly);
+                DrawCursor(doc, dc, sel, true, sys->cursorcolor);
         }
     }
 

--- a/src/grid.h
+++ b/src/grid.h
@@ -417,8 +417,7 @@ struct Grid {
             dc.DrawRectangle(g.x + g.width, g.y + g.height - 2, lw + 2, lw + 4);
             dc.DrawRectangle(g.x + g.width - lw - 1, g.y + g.height - 2 + 2 * te, lw + 1,
                              lw + 4 - 2 * te);
-            if (sel.TextEdit())
-                DrawCursor(doc, dc, sel, true, sys->cursorcolor);
+            if (sel.TextEdit()) DrawCursor(doc, dc, sel, true, sys->cursorcolor);
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,10 +3,6 @@
 
 static_assert(wxCHECK_VERSION(3, 2, 6), "wxWidgets < 3.2.6 is not supported.");
 
-#define SIMPLERENDER
-
-//#define SIMPLERENDER // for testing
-
 static const auto TS_VERSION = 24;
 static const auto g_grid_margin = 1;
 static const auto g_cell_margin = 2;
@@ -231,9 +227,7 @@ enum {
     A_HELP_OP_REF,
     A_FSWATCH,
     A_DEFBGCOL,
-    #ifdef SIMPLERENDER
-        A_DEFCURCOL,
-    #endif
+    A_DEFCURCOL,
     A_THINSELC,
     A_COPYCT,
     A_COPYBM,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,9 +3,7 @@
 
 static_assert(wxCHECK_VERSION(3, 2, 6), "wxWidgets < 3.2.6 is not supported.");
 
-#ifndef __WXMSW__
 #define SIMPLERENDER
-#endif
 
 //#define SIMPLERENDER // for testing
 

--- a/src/selection.h
+++ b/src/selection.h
@@ -364,7 +364,7 @@ class Selection {
         delete old;
         xs = ys = 1;
         EnterEdit(doc, MaxCursor(), MaxCursor());
-        doc->Refresh();
+        doc->sw->Refresh();
         return nullptr;
     }
 

--- a/src/selection.h
+++ b/src/selection.h
@@ -134,7 +134,7 @@ class Selection {
             // FIXME: this is null in the case of a whole column selection, and doesn't do the right
             // thing.
             if (g) g->cell->ResetChildren();
-            doc->RefreshMove(*this);
+            doc->RefreshMove();
         } else {
             if (ctrl && dx)  // implies textedit
             {
@@ -299,7 +299,7 @@ class Selection {
                     }
                 };
             }
-            doc->RefreshMove(*this);
+            doc->RefreshMove();
         };
     }
 
@@ -338,7 +338,7 @@ class Selection {
                 x = y = 0;
         }
         EnterEdit(doc, 0, MaxCursor());
-        doc->RefreshMove(*this);
+        doc->RefreshMove();
     }
 
     const wxChar *Wrap(Document *doc) {
@@ -389,6 +389,6 @@ class Selection {
             x = g->xs - 1;
             y = g->ys - 1;
         }
-        doc->RefreshMove(*this);
+        doc->RefreshMove();
     }
 };

--- a/src/selection.h
+++ b/src/selection.h
@@ -318,7 +318,7 @@ class Selection {
         }
     }
 
-    void Next(Document *doc, wxDC &dc, bool backwards) {
+    void Next(Document *doc, bool backwards) {
         ExitEdit(doc);
         if (backwards) {
             if (x > 0)
@@ -383,7 +383,7 @@ class Selection {
         return GetCell();
     }
 
-    void HomeEnd(Document *doc, wxDC &dc, bool ishome) {
+    void HomeEnd(Document *doc, bool ishome) {
         xs = ys = 1;
         if (ishome)
             x = y = 0;

--- a/src/selection.h
+++ b/src/selection.h
@@ -121,7 +121,7 @@ class Selection {
         return TEXT_CHAR;
     }
 
-    void Dir(Document *doc, bool ctrl, bool shift, wxDC &dc, int dx, int dy, int &v, int &vs,
+    void Dir(Document *doc, bool ctrl, bool shift, int dx, int dy, int &v, int &vs,
              int &ovs, bool notboundaryperp, bool notboundarypar, bool exitedit) {
         if (ctrl && !textedit) {
             g->cell->AddUndo(doc);
@@ -303,17 +303,17 @@ class Selection {
         };
     }
 
-    void Cursor(Document *doc, int k, bool ctrl, bool shift, wxDC &dc, bool exitedit = false) {
+    void Cursor(Document *doc, int k, bool ctrl, bool shift, bool exitedit = false) {
         switch (k) {
-            case A_UP: Dir(doc, ctrl, shift, dc, 0, -1, y, ys, xs, y != 0, y != 0, exitedit); break;
+            case A_UP: Dir(doc, ctrl, shift, 0, -1, y, ys, xs, y != 0, y != 0, exitedit); break;
             case A_DOWN:
-                Dir(doc, ctrl, shift, dc, 0, 1, y, ys, xs, y < g->ys, y < g->ys - 1, exitedit);
+                Dir(doc, ctrl, shift, 0, 1, y, ys, xs, y < g->ys, y < g->ys - 1, exitedit);
                 break;
             case A_LEFT:
-                Dir(doc, ctrl, shift, dc, -1, 0, x, xs, ys, x != 0, x != 0, exitedit);
+                Dir(doc, ctrl, shift, -1, 0, x, xs, ys, x != 0, x != 0, exitedit);
                 break;
             case A_RIGHT:
-                Dir(doc, ctrl, shift, dc, 1, 0, x, xs, ys, x < g->xs, x < g->xs - 1, exitedit);
+                Dir(doc, ctrl, shift, 1, 0, x, xs, ys, x < g->xs, x < g->xs - 1, exitedit);
                 break;
         }
     }

--- a/src/selection.h
+++ b/src/selection.h
@@ -134,9 +134,8 @@ class Selection {
             // FIXME: this is null in the case of a whole column selection, and doesn't do the right
             // thing.
             if (g) g->cell->ResetChildren();
-            doc->ScrollIfSelectionOutOfView(dc, *this, true);
+            doc->RefreshMove(*this);
         } else {
-            doc->DrawSelect(dc, *this);
             if (ctrl && dx)  // implies textedit
             {
                 if (cursor == cursorend) firstdx = dx;
@@ -300,7 +299,7 @@ class Selection {
                     }
                 };
             }
-            doc->DrawSelectMove(dc, *this);
+            doc->RefreshMove(*this);
         };
     }
 
@@ -320,7 +319,6 @@ class Selection {
     }
 
     void Next(Document *doc, wxDC &dc, bool backwards) {
-        doc->DrawSelect(dc, *this);
         ExitEdit(doc);
         if (backwards) {
             if (x > 0)
@@ -342,7 +340,7 @@ class Selection {
                 x = y = 0;
         }
         EnterEdit(doc, 0, MaxCursor());
-        doc->DrawSelectMove(dc, *this);
+        doc->RefreshMove(*this);
     }
 
     const wxChar *Wrap(Document *doc) {
@@ -386,7 +384,6 @@ class Selection {
     }
 
     void HomeEnd(Document *doc, wxDC &dc, bool ishome) {
-        doc->DrawSelect(dc, *this);
         xs = ys = 1;
         if (ishome)
             x = y = 0;
@@ -394,6 +391,6 @@ class Selection {
             x = g->xs - 1;
             y = g->ys - 1;
         }
-        doc->DrawSelectMove(dc, *this);
+        doc->RefreshMove(*this);
     }
 };

--- a/src/selection.h
+++ b/src/selection.h
@@ -121,8 +121,8 @@ class Selection {
         return TEXT_CHAR;
     }
 
-    void Dir(Document *doc, bool ctrl, bool shift, int dx, int dy, int &v, int &vs,
-             int &ovs, bool notboundaryperp, bool notboundarypar, bool exitedit) {
+    void Dir(Document *doc, bool ctrl, bool shift, int dx, int dy, int &v, int &vs, int &ovs,
+             bool notboundaryperp, bool notboundarypar, bool exitedit) {
         if (ctrl && !textedit) {
             g->cell->AddUndo(doc);
 
@@ -309,9 +309,7 @@ class Selection {
             case A_DOWN:
                 Dir(doc, ctrl, shift, 0, 1, y, ys, xs, y < g->ys, y < g->ys - 1, exitedit);
                 break;
-            case A_LEFT:
-                Dir(doc, ctrl, shift, -1, 0, x, xs, ys, x != 0, x != 0, exitedit);
-                break;
+            case A_LEFT: Dir(doc, ctrl, shift, -1, 0, x, xs, ys, x != 0, x != 0, exitedit); break;
             case A_RIGHT:
                 Dir(doc, ctrl, shift, 1, 0, x, xs, ys, x < g->xs, x < g->xs - 1, exitedit);
                 break;

--- a/src/system.h
+++ b/src/system.h
@@ -362,8 +362,7 @@ struct System {
 
     void UpdateStatus(Selection &s) {
         if (frame->GetStatusBar()) {
-            auto c = s.GetCell();
-            if (c && s.xs) {
+            if (Cell *c = s.GetCell(); c && s.xs) {
                 frame->SetStatusText(wxString::Format(_(L"Size %d"), -c->text.relsize), 3);
                 frame->SetStatusText(wxString::Format(_(L"Width %d"), s.g->colwidths[s.x]), 2);
                 frame->SetStatusText(
@@ -371,11 +370,6 @@ struct System {
                                      c->text.lastedit.FormatTime().c_str()),
                     1);
             }
-        }
-    }
-
-    void UpdateAmountStatus(Selection &s) {
-        if (frame->GetStatusBar()) {
             frame->SetStatusText(wxString::Format(_(L"%d cell(s)"), s.xs * s.ys), 4);
         }
     }

--- a/src/system.h
+++ b/src/system.h
@@ -53,9 +53,7 @@ struct System {
     uint lasttextcolor {0};
     uint lastbordcolor {0xA0A0A0};
     int customcolor {0xFFFFFF};
-    #ifdef SIMPLERENDER
     int cursorcolor {0x00FF00};
-    #endif
 
     System(bool portable)
         : cfg(portable ? (wxConfigBase *)new wxFileConfig(
@@ -85,9 +83,7 @@ struct System {
         cfg->Read(L"casesensitivesearch", &casesensitivesearch, casesensitivesearch);
         cfg->Read(L"defaultfontsize", &g_deftextsize, g_deftextsize);
         cfg->Read(L"customcolor", &customcolor, customcolor);
-        #ifdef SIMPLERENDER
-            cfg->Read(L"cursorcolor", &cursorcolor, cursorcolor);
-        #endif
+        cfg->Read(L"cursorcolor", &cursorcolor, cursorcolor);
         cfg->Read(L"showtoolbar", &showtoolbar, showtoolbar);
         cfg->Read(L"showstatusbar", &showstatusbar, showstatusbar);
         // fsw.Connect(wxID_ANY, wxID_ANY, wxEVT_FSWATCHER,

--- a/src/system.h
+++ b/src/system.h
@@ -177,6 +177,7 @@ struct System {
         Document *doc = nullptr;
         auto anyimagesfailed = false;
         auto start_loading_time = wxGetLocalTimeMillis();
+        int zoomlevel = 0;
 
         {  // limit destructors
             wxBusyCursor wait;
@@ -199,7 +200,7 @@ struct System {
             if (versionlastloaded > TS_VERSION) return _(L"File of newer version.");
             auto xs = versionlastloaded >= 21 ? dis.Read8() : 1;
             auto ys = versionlastloaded >= 21 ? dis.Read8() : 1;
-            auto zoomlevel = versionlastloaded >= 23 ? dis.Read8() : 0;
+            zoomlevel = versionlastloaded >= 23 ? dis.Read8() : 0;
             fakelasteditonload = wxDateTime::Now().GetValue();
 
             loadimageids.clear();
@@ -270,7 +271,6 @@ struct System {
                             doc->modified = true;
                         }
                         doc->InitWith(root, filename, ics, xs, ys);
-                        doc->initialzoomlevel = zoomlevel;
 
                         if (versionlastloaded >= 11) {
                             for (;;) {
@@ -316,7 +316,7 @@ struct System {
         }  // wait until all tasks are finished
 
         FileUsed(filename, doc);
-        doc->sw->Refresh();
+        doc->Zoom(zoomlevel, true);
         if (anyimagesfailed)
             wxMessageBox(_(L"PNG decode failed on some images in this document\nThey have been replaced by red squares."),
                          _(L"PNG decoder failure"), wxOK, frame);

--- a/src/system.h
+++ b/src/system.h
@@ -360,20 +360,6 @@ struct System {
         cfg->Flush();
     }
 
-    void UpdateStatus(Selection &s) {
-        if (frame->GetStatusBar()) {
-            if (Cell *c = s.GetCell(); c && s.xs) {
-                frame->SetStatusText(wxString::Format(_(L"Size %d"), -c->text.relsize), 3);
-                frame->SetStatusText(wxString::Format(_(L"Width %d"), s.g->colwidths[s.x]), 2);
-                frame->SetStatusText(
-                    wxString::Format(_(L"Edited %s %s"), c->text.lastedit.FormatDate().c_str(),
-                                     c->text.lastedit.FormatTime().c_str()),
-                    1);
-            }
-            frame->SetStatusText(wxString::Format(_(L"%d cell(s)"), s.xs * s.ys), 4);
-        }
-    }
-
     void SaveCheck() {
         loop(i, frame->nb->GetPageCount()) {
             ((TSCanvas *)frame->nb->GetPage(i))->doc->AutoSave(!frame->IsActive(), i);

--- a/src/system.h
+++ b/src/system.h
@@ -316,7 +316,7 @@ struct System {
         }  // wait until all tasks are finished
 
         FileUsed(filename, doc);
-        doc->Refresh();
+        doc->sw->Refresh();
         if (anyimagesfailed)
             wxMessageBox(_(L"PNG decode failed on some images in this document\nThey have been replaced by red squares."),
                          _(L"PNG decoder failure"), wxOK, frame);

--- a/src/text.h
+++ b/src/text.h
@@ -305,12 +305,7 @@ struct Text {
                             DrawRectangle(
                                 dc, color, cell->GetX(doc) + x1 + 2 + ixs + g_margin_extra,
                                 cell->GetY(doc) + l * h + 1 + cell->ycenteroff + g_margin_extra,
-                                x2 - x1, h - 1
-                                #ifdef SIMPLERENDER
-                                ,
-                                true
-                                #endif
-                                );
+                                x2 - x1, h - 1, true);
                     }
                 } else if (s.cursor >= start && s.cursor <= end) {
                     ls.Truncate(s.cursor - start);

--- a/src/text.h
+++ b/src/text.h
@@ -279,8 +279,7 @@ struct Text {
         ASSERT(s.cursor >= 0 && s.cursor <= (int)t.Len());
     }
 
-    void DrawCursor(Document *doc, wxDC &dc, Selection &s, bool full, uint color, bool cursoronly,
-                    int maxcolwidth) {
+    void DrawCursor(Document *doc, wxDC &dc, Selection &s, bool full, uint color, int maxcolwidth) {
         auto ixs = 0, iys = 0;
         if (!cell->tiny) sys->ImageSize(DisplayImage(), ixs, iys);
         if (ixs) ixs += 2;
@@ -295,7 +294,7 @@ struct Text {
                 auto end = start + len;
 
                 if (s.cursor != s.cursorend) {
-                    if (s.cursor <= end && s.cursorend >= start && !cursoronly) {
+                    if (s.cursor <= end && s.cursorend >= start) {
                         ls.Truncate(min(s.cursorend, end) - start);
                         auto x1 = 0, x2 = 0;
                         dc.GetTextExtent(ls, &x2, nullptr);

--- a/src/text.h
+++ b/src/text.h
@@ -311,8 +311,8 @@ struct Text {
                     auto x = 0;
                     dc.GetTextExtent(ls, &x, nullptr);
                     DrawRectangle(dc, color, cell->GetX(doc) + x + 1 + ixs + g_margin_extra,
-                            cell->GetY(doc) + l * h + 1 + cell->ycenteroff + g_margin_extra, 2,
-                            h - 2);
+                                  cell->GetY(doc) + l * h + 1 + cell->ycenteroff + g_margin_extra,
+                                  2, h - 2);
                     break;
                 }
 

--- a/src/treesheets_impl.h
+++ b/src/treesheets_impl.h
@@ -2,7 +2,6 @@
 struct TreeSheetsScriptImpl : public ScriptInterface {
     Document *doc = nullptr;
     Cell *cur = nullptr;
-    wxDC *dc = nullptr;
     bool docmodified = false;
 
     enum { max_new_grid_cells = 256 * 256 };  // Don't allow crazy sizes.
@@ -19,7 +18,7 @@ struct TreeSheetsScriptImpl : public ScriptInterface {
         docmodified = true;
     }
 
-    std::string ScriptRun(const char *filename, wxDC &_dc) {
+    std::string ScriptRun(const char *filename) {
         SwitchToCurrentDoc();
 
         bool dump_builtins = false;
@@ -27,9 +26,7 @@ struct TreeSheetsScriptImpl : public ScriptInterface {
             //dump_builtins = true;
         #endif
 
-        dc = &_dc;
         auto err = RunLobster(filename, {}, dump_builtins);
-        dc = nullptr;
 
         doc->rootgrid->ResetChildren();
         doc->Refresh();

--- a/src/treesheets_impl.h
+++ b/src/treesheets_impl.h
@@ -106,7 +106,7 @@ struct TreeSheetsScriptImpl : public ScriptInterface {
             Selection s(cur->grid, x, y, xs, ys);
             cur->grid->MultiCellDeleteSub(doc, s);
             doc->SetSelect(Selection());
-            doc->Zoom(-100, *dc);
+            doc->Zoom(-100);
         }
     }
 

--- a/src/treesheets_impl.h
+++ b/src/treesheets_impl.h
@@ -29,7 +29,7 @@ struct TreeSheetsScriptImpl : public ScriptInterface {
         auto err = RunLobster(filename, {}, dump_builtins);
 
         doc->rootgrid->ResetChildren();
-        doc->Refresh();
+        doc->sw->Refresh();
 
         doc = nullptr;
         cur = nullptr;

--- a/src/tscanvas.h
+++ b/src/tscanvas.h
@@ -30,22 +30,19 @@ struct TSCanvas : public wxScrolledCanvas {
         // TODO: lastmousepos doesn't seem correct anymore after a scroll operation in latest
         // wxWidgets.
         /*
-        doc->Hover(lastmousepos.x / doc->currentviewscale,
-                   lastmousepos.y / doc->currentviewscale,
-                   dc);
         */
     };
 
-    void UpdateHover(int mx, int my, wxDC &dc) {
-        int x, y;
-        CalcUnscrolledPosition(mx, my, &x, &y);
-        DoPrepareDC(dc);
-        doc->Hover(x / doc->currentviewscale, y / doc->currentviewscale, dc);
+    void RefreshHover(int mx, int my, wxDC &dc) {
+        doc->mx = mx;
+        doc->my = my;
+        doc->updatehover = true;
+        doc->Refresh();
     }
 
     void OnMotion(wxMouseEvent &me) {
         wxClientDC dc(this);
-        UpdateHover(me.GetX(), me.GetY(), dc);
+        RefreshHover(me.GetX(), me.GetY(), dc);
         if (me.LeftIsDown() || me.RightIsDown()) {
             if (me.AltDown() && me.ShiftDown()) {
                 doc->Copy(A_DRAGANDDROP);
@@ -63,7 +60,7 @@ struct TSCanvas : public wxScrolledCanvas {
         if (mx < 0 || my < 0)
             return;  // for some reason, using just the "menu" key sends a right-click at (-1, -1)
         wxClientDC dc(this);
-        UpdateHover(mx, my, dc);
+        RefreshHover(mx, my, dc);
         doc->Select(dc, right, isctrlshift);
     }
 
@@ -95,7 +92,7 @@ struct TSCanvas : public wxScrolledCanvas {
 
     void OnLeftDoubleClick(wxMouseEvent &me) {
         wxClientDC dc(this);
-        UpdateHover(me.GetX(), me.GetY(), dc);
+        RefreshHover(me.GetX(), me.GetY(), dc);
         Status(doc->DoubleClick());
     }
 
@@ -135,14 +132,14 @@ struct TSCanvas : public wxScrolledCanvas {
             if (!steps) return;
             mousewheelaccum -= steps * me.GetWheelDelta();
 
-            UpdateHover(me.GetX(), me.GetY(), dc);
+            RefreshHover(me.GetX(), me.GetY(), dc);
             Status(doc->Wheel(steps, me.AltDown(), ctrl, me.ShiftDown()));
         } else if (me.GetWheelAxis()) {
             CursorScroll(me.GetWheelRotation() * g_scrollratewheel, 0);
-            UpdateHover(me.GetX(), me.GetY(), dc);
+            RefreshHover(me.GetX(), me.GetY(), dc);
         } else {
             CursorScroll(0, -me.GetWheelRotation() * g_scrollratewheel);
-            UpdateHover(me.GetX(), me.GetY(), dc);
+            RefreshHover(me.GetX(), me.GetY(), dc);
         }
     }
 

--- a/src/tscanvas.h
+++ b/src/tscanvas.h
@@ -136,7 +136,7 @@ struct TSCanvas : public wxScrolledCanvas {
             mousewheelaccum -= steps * me.GetWheelDelta();
 
             UpdateHover(me.GetX(), me.GetY(), dc);
-            Status(doc->Wheel(dc, steps, me.AltDown(), ctrl, me.ShiftDown()));
+            Status(doc->Wheel(steps, me.AltDown(), ctrl, me.ShiftDown()));
         } else if (me.GetWheelAxis()) {
             CursorScroll(me.GetWheelRotation() * g_scrollratewheel, 0);
             UpdateHover(me.GetX(), me.GetY(), dc);

--- a/src/tscanvas.h
+++ b/src/tscanvas.h
@@ -51,7 +51,7 @@ struct TSCanvas : public wxScrolledCanvas {
 
     void SelectClick(int mx, int my, bool right, int isctrlshift) {
         if (mx < 0 || my < 0)
-            return; // for some reason, using just the "menu" key sends a right-click at (-1, -1)
+            return;  // for some reason, using just the "menu" key sends a right-click at (-1, -1)
         doc->selectclick = true;
         doc->clickright = right;
         doc->clickisctrlshift = isctrlshift;

--- a/src/tscanvas.h
+++ b/src/tscanvas.h
@@ -41,8 +41,8 @@ struct TSCanvas : public wxScrolledCanvas {
     }
 
     void OnMotion(wxMouseEvent &me) {
-        RefreshHover(me.GetX(), me.GetY());
         if (me.LeftIsDown() || me.RightIsDown()) {
+            RefreshHover(me.GetX(), me.GetY());
             if (me.AltDown() && me.ShiftDown()) {
                 doc->Copy(A_DRAGANDDROP);
             } else {

--- a/src/tscanvas.h
+++ b/src/tscanvas.h
@@ -23,7 +23,14 @@ struct TSCanvas : public wxScrolledCanvas {
     }
 
     void OnPaint(wxPaintEvent &event) {
-        wxAutoBufferedPaintDC dc(this);
+        #ifndef __WXMSW__
+            wxPaintDC dc(this);
+        #else
+            auto sz = GetClientSize();
+            if (sz.GetX() <= 0 || sz.GetY() <= 0) return;
+            wxBitmap buffer(sz.GetX(), sz.GetY(), 24);
+            wxBufferedPaintDC dc(this, buffer);
+        #endif
         doc->Draw(dc);
     };
 

--- a/src/tscanvas.h
+++ b/src/tscanvas.h
@@ -127,15 +127,11 @@ struct TSCanvas : public wxScrolledCanvas {
             int steps = mousewheelaccum / me.GetWheelDelta();
             if (!steps) return;
             mousewheelaccum -= steps * me.GetWheelDelta();
-
-            RefreshHover(me.GetX(), me.GetY());
             Status(doc->Wheel(steps, me.AltDown(), ctrl, me.ShiftDown()));
         } else if (me.GetWheelAxis()) {
             CursorScroll(me.GetWheelRotation() * g_scrollratewheel, 0);
-            RefreshHover(me.GetX(), me.GetY());
         } else {
             CursorScroll(0, -me.GetWheelRotation() * g_scrollratewheel);
-            RefreshHover(me.GetX(), me.GetY());
         }
     }
 

--- a/src/tscanvas.h
+++ b/src/tscanvas.h
@@ -33,7 +33,7 @@ struct TSCanvas : public wxScrolledCanvas {
         */
     };
 
-    void RefreshHover(int mx, int my, wxDC &dc) {
+    void RefreshHover(int mx, int my) {
         doc->mx = mx;
         doc->my = my;
         doc->updatehover = true;
@@ -41,13 +41,12 @@ struct TSCanvas : public wxScrolledCanvas {
     }
 
     void OnMotion(wxMouseEvent &me) {
-        wxClientDC dc(this);
-        RefreshHover(me.GetX(), me.GetY(), dc);
+        RefreshHover(me.GetX(), me.GetY());
         if (me.LeftIsDown() || me.RightIsDown()) {
             if (me.AltDown() && me.ShiftDown()) {
                 doc->Copy(A_DRAGANDDROP);
             } else {
-                doc->Drag(dc);
+                doc->Drag();
             }
         } else if (me.MiddleIsDown()) {
             wxPoint p = me.GetPosition() - lastmousepos;
@@ -59,9 +58,8 @@ struct TSCanvas : public wxScrolledCanvas {
     void SelectClick(int mx, int my, bool right, int isctrlshift) {
         if (mx < 0 || my < 0)
             return;  // for some reason, using just the "menu" key sends a right-click at (-1, -1)
-        wxClientDC dc(this);
-        RefreshHover(mx, my, dc);
-        doc->Select(dc, right, isctrlshift);
+        RefreshHover(mx, my);
+        doc->Select(right, isctrlshift);
     }
 
     void OnLeftDown(wxMouseEvent &me) {
@@ -91,8 +89,7 @@ struct TSCanvas : public wxScrolledCanvas {
     }
 
     void OnLeftDoubleClick(wxMouseEvent &me) {
-        wxClientDC dc(this);
-        RefreshHover(me.GetX(), me.GetY(), dc);
+        RefreshHover(me.GetX(), me.GetY());
         Status(doc->DoubleClick());
     }
 
@@ -132,14 +129,14 @@ struct TSCanvas : public wxScrolledCanvas {
             if (!steps) return;
             mousewheelaccum -= steps * me.GetWheelDelta();
 
-            RefreshHover(me.GetX(), me.GetY(), dc);
+            RefreshHover(me.GetX(), me.GetY());
             Status(doc->Wheel(steps, me.AltDown(), ctrl, me.ShiftDown()));
         } else if (me.GetWheelAxis()) {
             CursorScroll(me.GetWheelRotation() * g_scrollratewheel, 0);
-            RefreshHover(me.GetX(), me.GetY(), dc);
+            RefreshHover(me.GetX(), me.GetY());
         } else {
             CursorScroll(0, -me.GetWheelRotation() * g_scrollratewheel);
-            RefreshHover(me.GetX(), me.GetY(), dc);
+            RefreshHover(me.GetX(), me.GetY());
         }
     }
 

--- a/src/tscanvas.h
+++ b/src/tscanvas.h
@@ -43,11 +43,12 @@ struct TSCanvas : public wxScrolledCanvas {
 
     void OnMotion(wxMouseEvent &me) {
         if (me.LeftIsDown() || me.RightIsDown()) {
-            RefreshHover(me.GetX(), me.GetY());
             if (me.AltDown() && me.ShiftDown()) {
+                RefreshHover(me.GetX(), me.GetY());
                 doc->Copy(A_DRAGANDDROP);
             } else {
-                doc->Drag();
+                doc->drag = true;
+                RefreshHover(me.GetX(), me.GetY());
             }
         } else if (me.MiddleIsDown()) {
             wxPoint p = me.GetPosition() - lastmousepos;

--- a/src/tscanvas.h
+++ b/src/tscanvas.h
@@ -37,7 +37,7 @@ struct TSCanvas : public wxScrolledCanvas {
         doc->mx = mx;
         doc->my = my;
         doc->updatehover = true;
-        doc->Refresh();
+        doc->sw->Refresh();
     }
 
     void OnMotion(wxMouseEvent &me) {

--- a/src/tscanvas.h
+++ b/src/tscanvas.h
@@ -122,7 +122,6 @@ struct TSCanvas : public wxScrolledCanvas {
     void OnMouseWheel(wxMouseEvent &me) {
         bool ctrl = me.CmdDown();
         if (sys->zoomscroll) ctrl = !ctrl;
-        wxClientDC dc(this);
         if (me.AltDown() || ctrl || me.ShiftDown()) {
             mousewheelaccum += me.GetWheelRotation();
             int steps = mousewheelaccum / me.GetWheelDelta();

--- a/src/tscanvas.h
+++ b/src/tscanvas.h
@@ -96,7 +96,7 @@ struct TSCanvas : public wxScrolledCanvas {
     void OnLeftDoubleClick(wxMouseEvent &me) {
         wxClientDC dc(this);
         UpdateHover(me.GetX(), me.GetY(), dc);
-        Status(doc->DoubleClick(dc));
+        Status(doc->DoubleClick());
     }
 
     void OnKeyDown(wxKeyEvent &ce) { ce.Skip(); }

--- a/src/tscanvas.h
+++ b/src/tscanvas.h
@@ -55,9 +55,7 @@ struct TSCanvas : public wxScrolledCanvas {
         doc->selectclick = true;
         doc->clickright = right;
         doc->clickisctrlshift = isctrlshift;
-        doc->mx = mx;
-        doc->my = my;
-        Refresh();
+        RefreshHover(mx, my);
     }
 
     void OnLeftDown(wxMouseEvent &me) {
@@ -87,8 +85,8 @@ struct TSCanvas : public wxScrolledCanvas {
     }
 
     void OnLeftDoubleClick(wxMouseEvent &me) {
+        doc->doubleclick = true;
         RefreshHover(me.GetX(), me.GetY());
-        Status(doc->DoubleClick());
     }
 
     void OnKeyDown(wxKeyEvent &ce) { ce.Skip(); }

--- a/src/tscanvas.h
+++ b/src/tscanvas.h
@@ -51,9 +51,13 @@ struct TSCanvas : public wxScrolledCanvas {
 
     void SelectClick(int mx, int my, bool right, int isctrlshift) {
         if (mx < 0 || my < 0)
-            return;  // for some reason, using just the "menu" key sends a right-click at (-1, -1)
-        RefreshHover(mx, my);
-        doc->Select(right, isctrlshift);
+            return; // for some reason, using just the "menu" key sends a right-click at (-1, -1)
+        doc->selectclick = true;
+        doc->clickright = right;
+        doc->clickisctrlshift = isctrlshift;
+        doc->mx = mx;
+        doc->my = my;
+        Refresh();
     }
 
     void OnLeftDown(wxMouseEvent &me) {

--- a/src/tscanvas.h
+++ b/src/tscanvas.h
@@ -23,7 +23,7 @@ struct TSCanvas : public wxScrolledCanvas {
     }
 
     void OnPaint(wxPaintEvent &event) {
-        wxPaintDC dc(this);
+        wxAutoBufferedPaintDC dc(this);
         doc->Draw(dc);
     };
 

--- a/src/tscanvas.h
+++ b/src/tscanvas.h
@@ -24,13 +24,7 @@ struct TSCanvas : public wxScrolledCanvas {
 
     void OnPaint(wxPaintEvent &event) {
         wxPaintDC dc(this);
-        // DoPrepareDC(dc);
         doc->Draw(dc);
-        // Display has been re-layouted, compute hover selection again.
-        // TODO: lastmousepos doesn't seem correct anymore after a scroll operation in latest
-        // wxWidgets.
-        /*
-        */
     };
 
     void RefreshHover(int mx, int my) {

--- a/src/tsframe.h
+++ b/src/tsframe.h
@@ -596,10 +596,8 @@ struct TSFrame : wxFrame {
             _(L"Set a custom color for the color dropdowns from the selected cell background"));
         MyAppend(optmenu, A_DEFBGCOL, _(L"Background color..."),
                  _(L"Set the color for the document background"));
-        #ifdef SIMPLERENDER
         MyAppend(optmenu, A_DEFCURCOL, _(L"Cu&rsor color..."),
                  _(L"Set the color for the text cursor"));
-        #endif
         optmenu->AppendSeparator();
         optmenu->AppendCheckItem(
             A_SHOWTBAR, _(L"Toolbar"),

--- a/src/tsframe.h
+++ b/src/tsframe.h
@@ -1158,8 +1158,8 @@ struct TSFrame : wxFrame {
             doc->SetSearchFilter(sys->searchstring.Len() != 0);
             doc->searchfilter = true;
         }
-        doc->Refresh();
-        GetCurTab()->Status();
+        sw->Refresh();
+        sw->Status();
     }
 
     void OnSearchReplaceEnter(wxCommandEvent &ce) {

--- a/src/tsframe.h
+++ b/src/tsframe.h
@@ -893,7 +893,8 @@ struct TSFrame : wxFrame {
         AddTBIcon(_(L"New (CTRL+n)"), wxID_NEW, iconpath, L"filenew.svg", L"filenew_dark.svg");
         AddTBIcon(_(L"Open (CTRL+o)"), wxID_OPEN, iconpath, L"fileopen.svg", L"fileopen_dark.svg");
         AddTBIcon(_(L"Save (CTRL+s)"), wxID_SAVE, iconpath, L"filesave.svg", L"filesave_dark.svg");
-        AddTBIcon(_(L"Save as..."), wxID_SAVEAS, iconpath, L"filesaveas.svg", L"filesaveas_dark.svg");
+        AddTBIcon(_(L"Save as..."), wxID_SAVEAS, iconpath, L"filesaveas.svg",
+                  L"filesaveas_dark.svg");
         SEPARATOR;
         AddTBIcon(_(L"Undo (CTRL+z)"), wxID_UNDO, iconpath, L"undo.svg", L"undo_dark.svg");
         AddTBIcon(_(L"Copy (CTRL+c)"), wxID_COPY, iconpath, L"editcopy.svg", L"editcopy_dark.svg");

--- a/src/tsframe.h
+++ b/src/tsframe.h
@@ -1139,11 +1139,8 @@ struct TSFrame : wxFrame {
                 } else if (ce.GetId() >= A_TAGSET && ce.GetId() < A_SCRIPT) {
                     sw->Status(sw->doc->TagSet(ce.GetId() - A_TAGSET));
                 } else if (ce.GetId() >= A_SCRIPT && ce.GetId() < A_MAXACTION) {
-                    wxClientDC dc(sw);
-                    sw->DoPrepareDC(dc);
-                    sw->doc->ShiftToCenter(dc);
                     auto msg =
-                        tssi.ScriptRun(scripts.GetHistoryFile(ce.GetId() - A_SCRIPT).c_str(), dc);
+                        tssi.ScriptRun(scripts.GetHistoryFile(ce.GetId() - A_SCRIPT).c_str());
                     msg.erase(std::remove(msg.begin(), msg.end(), '\n'), msg.end());
                     sw->Status(wxString(msg));
                 } else {

--- a/src/tsframe.h
+++ b/src/tsframe.h
@@ -1208,6 +1208,20 @@ struct TSFrame : wxFrame {
         SetStatusWidths(5, swidths);
     }
 
+    void UpdateStatus(Selection &s) {
+        if (GetStatusBar()) {
+            if (Cell *c = s.GetCell(); c && s.xs) {
+                SetStatusText(wxString::Format(_(L"Size %d"), -c->text.relsize), 3);
+                SetStatusText(wxString::Format(_(L"Width %d"), s.g->colwidths[s.x]), 2);
+                SetStatusText(
+                    wxString::Format(_(L"Edited %s %s"), c->text.lastedit.FormatDate().c_str(),
+                                     c->text.lastedit.FormatTime().c_str()),
+                    1);
+            }
+            SetStatusText(wxString::Format(_(L"%d cell(s)"), s.xs * s.ys), 4);
+        }
+    }
+
     void OnDPIChanged(wxDPIChangedEvent &dce) {
         // block all other events until we finished preparing
         wxEventBlocker blocker(this);

--- a/src/tsframe.h
+++ b/src/tsframe.h
@@ -1027,20 +1027,20 @@ struct TSFrame : wxFrame {
             case A_SHOWSBAR:
                 if (!IsFullScreen()) {
                     sys->cfg->Write(L"showstatusbar", sys->showstatusbar = ce.IsChecked());
-                    auto wsb = this->GetStatusBar();
+                    auto wsb = GetStatusBar();
                     wsb->Show(sys->showstatusbar);
-                    this->SendSizeEvent();
-                    this->Refresh();
+                    SendSizeEvent();
+                    Refresh();
                     wsb->Refresh();
                 }
                 break;
             case A_SHOWTBAR:
                 if (!IsFullScreen()) {
                     sys->cfg->Write(L"showtoolbar", sys->showtoolbar = ce.IsChecked());
-                    auto wtb = this->GetToolBar();
+                    auto wtb = GetToolBar();
                     wtb->Show(sys->showtoolbar);
-                    this->SendSizeEvent();
-                    this->Refresh();
+                    SendSizeEvent();
+                    Refresh();
                     wtb->Refresh();
                 }
                 break;
@@ -1128,7 +1128,7 @@ struct TSFrame : wxFrame {
             #endif
             case wxID_EXIT:
                 fromclosebox = false;
-                this->Close();
+                Close();
                 break;
             case wxID_CLOSE: sw->doc->Action(ce.GetId()); break;  // sw dangling pointer on return
             default:
@@ -1160,7 +1160,6 @@ struct TSFrame : wxFrame {
             doc->searchfilter = true;
         }
         sw->Refresh();
-        sw->Status();
     }
 
     void OnSearchReplaceEnter(wxCommandEvent &ce) {

--- a/src/wxtools.h
+++ b/src/wxtools.h
@@ -14,7 +14,7 @@ struct DropTarget : wxDropTarget {
     wxDragResult OnDragOver(wxCoord x, wxCoord y, wxDragResult def) {
         auto sw = sys->frame->GetCurTab();
         wxClientDC dc(sw);
-        sw->UpdateHover(x, y, dc);
+        sw->RefreshHover(x, y, dc);
         return sw->doc->hover.g ? wxDragCopy : wxDragNone;
     }
 

--- a/src/wxtools.h
+++ b/src/wxtools.h
@@ -13,7 +13,6 @@ struct DropTarget : wxDropTarget {
 
     wxDragResult OnDragOver(wxCoord x, wxCoord y, wxDragResult def) {
         auto sw = sys->frame->GetCurTab();
-        wxClientDC dc(sw);
         sw->RefreshHover(x, y);
         return sw->doc->hover.g ? wxDragCopy : wxDragNone;
     }

--- a/src/wxtools.h
+++ b/src/wxtools.h
@@ -14,7 +14,7 @@ struct DropTarget : wxDropTarget {
     wxDragResult OnDragOver(wxCoord x, wxCoord y, wxDragResult def) {
         auto sw = sys->frame->GetCurTab();
         wxClientDC dc(sw);
-        sw->RefreshHover(x, y, dc);
+        sw->RefreshHover(x, y);
         return sw->doc->hover.g ? wxDragCopy : wxDragNone;
     }
 


### PR DESCRIPTION
This Pull Requests serves for discussion of a rewrite.

Background: wxWidgets has deprecated wxClientDC starting with 3.3.0. This is a refactoring to just do the drawing specifics only within the Drawing routine with wxPaintDC.