### PR TITLE
Only support simple rendering

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -219,12 +219,10 @@ struct Document {
     void DrawSelect(wxDC &dc, Selection &sel, bool refreshinstead = false,
                     bool cursoronly = false) {
         sys->UpdateAmountStatus(sel);
-        #ifdef SIMPLERENDER
         if (refreshinstead) {
             Refresh();
             return;
         }
-        #endif
         if (!sel.g) return;
         ResetFont();
         sel.g->DrawSelect(this, dc, sel, cursoronly);
@@ -679,7 +677,7 @@ struct Document {
             hover.g = nullptr;
             redrawpending = true;
             sys->UpdateStatus(selected);
-            #ifdef SIMPLERENDER
+            #ifndef __WXMSW__ 
                 // wxWidgets (wxGTK, wxMAC) does not always automatically update the scrollbar
                 // to new canvas size and current position within after zoom so force it manually
                 int curx, cury;
@@ -1135,7 +1133,6 @@ struct Document {
                 return nullptr;
             }
 
-            #ifdef SIMPLERENDER
             case A_DEFCURCOL: {
                 if (auto color = PickColor(sys->frame, sys->cursorcolor); color != (uint)-1) {
                     sys->cfg->Write(L"cursorcolor", sys->cursorcolor = color);
@@ -1143,7 +1140,6 @@ struct Document {
                 }
                 return nullptr;
             }
-            #endif
 
             case A_SEARCHNEXT:
             case A_SEARCHPREV: {

--- a/src/grid.h
+++ b/src/grid.h
@@ -399,9 +399,6 @@ struct Grid {
     }
 
     void DrawSelect(Document *doc, wxDC &dc, Selection &sel, bool cursoronly) {
-        #ifndef SIMPLERENDER
-        dc.SetLogicalFunction(wxINVERT);
-        #endif
         if (sel.Thin()) {
             if (!cursoronly) DrawInsert(doc, dc, sel, 0);
         } else {
@@ -423,19 +420,9 @@ struct Grid {
                 dc.DrawRectangle(g.x + g.width - lw - 1, g.y + g.height - 2 + 2 * te, lw + 1,
                                  lw + 4 - 2 * te);
             }
-            #ifndef SIMPLERENDER
-            dc.SetLogicalFunction(wxXOR);
-            #endif
             if (sel.TextEdit())
-            #ifdef SIMPLERENDER
                 DrawCursor(doc, dc, sel, true, sys->cursorcolor, cursoronly);
-            #else
-                DrawCursor(doc, dc, sel, true, 0xFFFF, cursoronly);
-            #endif
         }
-        #ifndef SIMPLERENDER
-        dc.SetLogicalFunction(wxCOPY);
-        #endif
     }
 
     void DeleteCells(int dx, int dy, int nxs, int nys) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,12 +3,6 @@
 
 static_assert(wxCHECK_VERSION(3, 2, 6), "wxWidgets < 3.2.6 is not supported.");
 
-#ifndef __WXMSW__
-#define SIMPLERENDER
-#endif
-
-//#define SIMPLERENDER // for testing
-
 static const auto TS_VERSION = 24;
 static const auto g_grid_margin = 1;
 static const auto g_cell_margin = 2;
@@ -233,9 +227,7 @@ enum {
     A_HELP_OP_REF,
     A_FSWATCH,
     A_DEFBGCOL,
-    #ifdef SIMPLERENDER
-        A_DEFCURCOL,
-    #endif
+    A_DEFCURCOL,
     A_THINSELC,
     A_COPYCT,
     A_COPYBM,

--- a/src/system.h
+++ b/src/system.h
@@ -53,9 +53,7 @@ struct System {
     uint lasttextcolor {0};
     uint lastbordcolor {0xA0A0A0};
     int customcolor {0xFFFFFF};
-    #ifdef SIMPLERENDER
     int cursorcolor {0x00FF00};
-    #endif
 
     System(bool portable)
         : cfg(portable ? (wxConfigBase *)new wxFileConfig(
@@ -85,9 +83,7 @@ struct System {
         cfg->Read(L"casesensitivesearch", &casesensitivesearch, casesensitivesearch);
         cfg->Read(L"defaultfontsize", &g_deftextsize, g_deftextsize);
         cfg->Read(L"customcolor", &customcolor, customcolor);
-        #ifdef SIMPLERENDER
-            cfg->Read(L"cursorcolor", &cursorcolor, cursorcolor);
-        #endif
+        cfg->Read(L"cursorcolor", &cursorcolor, cursorcolor);
         cfg->Read(L"showtoolbar", &showtoolbar, showtoolbar);
         cfg->Read(L"showstatusbar", &showstatusbar, showstatusbar);
         // fsw.Connect(wxID_ANY, wxID_ANY, wxEVT_FSWATCHER,

--- a/src/text.h
+++ b/src/text.h
@@ -305,12 +305,7 @@ struct Text {
                             DrawRectangle(
                                 dc, color, cell->GetX(doc) + x1 + 2 + ixs + g_margin_extra,
                                 cell->GetY(doc) + l * h + 1 + cell->ycenteroff + g_margin_extra,
-                                x2 - x1, h - 1
-                                #ifdef SIMPLERENDER
-                                ,
-                                true
-                                #endif
-                                );
+                                x2 - x1, h - 1, true);
                     }
                 } else if (s.cursor >= start && s.cursor <= end) {
                     ls.Truncate(s.cursor - start);

--- a/src/tsframe.h
+++ b/src/tsframe.h
@@ -596,7 +596,7 @@ struct TSFrame : wxFrame {
             _(L"Set a custom color for the color dropdowns from the selected cell background"));
         MyAppend(optmenu, A_DEFBGCOL, _(L"Background color..."),
                  _(L"Set the color for the document background"));
-        #ifdef SIMPLERENDER
+        #ifndef __WXMSW__
         MyAppend(optmenu, A_DEFCURCOL, _(L"Cu&rsor color..."),
                  _(L"Set the color for the text cursor"));
         #endif


### PR DESCRIPTION
- Client server architecture for device context will not be supported any longer
- This means:
 - Just use SIMPLERENDER because everythings needs to be completely drawn
 - Client color is handled differently on Windows so no custom cursor color there