### PR TITLE
Do not use minimal rectangle when we scroll to selection

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -247,7 +247,7 @@ struct Document {
             int canvasw, canvash;
             sw->GetClientSize(&canvasw, &canvash);
             if ((layoutys > canvash || layoutxs > canvasw) && sel.g) {
-                wxRect r = sel.g->GetRect(this, sel, true);
+                wxRect r = sel.g->GetRect(this, sel);
                 if (r.y < scrolly || r.y + r.height > maxy || r.x < scrollx || r.x + r.width > maxx) {
                     sw->Scroll(r.width > canvasw || r.x < scrollx ? r.x
                                : r.x + r.width > maxx             ? r.x + r.width - canvasw


### PR DESCRIPTION
Before this commit, the TSCanvas used the minimal rectangle when we scrolled to selection of a cell, but when the user navigated by key arrows afterwards over a thin selection, the full rectangle was returned and the conditions were met to scroll further. After this, with another cell selected, the minimal rectangle was returned, but no more a condition to scroll was met. This behavior caused an inconsistent user experience when e.g. the user zooms in and out and navigates afterwards with the arrow keys.