### PR TITLE
Update ts.po

### DIFF
--- a/TS/translations/de/ts.po
+++ b/TS/translations/de/ts.po
@@ -261,7 +261,7 @@ msgid "Autosave load"
 msgstr "Automatische Sicherungskopien laden"
 
 msgid "Background color..."
-msgstr "Benutzerdefinierte Cursorfarbe..."
+msgstr "Hintergrundfarbe"
 
 msgid "Backup files"
 msgstr "Sicherungskopien"


### PR DESCRIPTION
Translation Error. Background Color was named coursor color in german.