### PR TITLE
Check whether there is still a tab

### DIFF
--- a/src/tsframe.h
+++ b/src/tsframe.h
@@ -1186,7 +1186,7 @@ struct TSFrame : wxFrame {
     }
 
     void OnUpdateStatusBarRequest(wxCommandEvent &ce) {
-        UpdateStatus(GetCurTab()->doc->selected);
+        if (TSCanvas *tab = GetCurTab()) UpdateStatus(tab->doc->selected);
     }
 
     void UpdateStatus(const Selection &s) {


### PR DESCRIPTION
Asynchronous event can be somehow even processed when the application is destroyed, so check for the existence of the wxAuiNotebook