### PR TITLE
Add Alt+C as mnemonic

### DIFF
--- a/src/tsframe.h
+++ b/src/tsframe.h
@@ -710,7 +710,7 @@ struct TSFrame : wxFrame {
         menubar->Append(semenu, _(L"&Search"));
         menubar->Append(viewmenu, _(L"&View"));
         menubar->Append(optmenu, _(L"&Options"));
-        menubar->Append(scriptmenu, _(L"Script"));
+        menubar->Append(scriptmenu, _(L"S&cript"));
         menubar->Append(langmenu, _(L"&Program"));
         menubar->Append(helpmenu,
                         #ifdef __WXMAC__


### PR DESCRIPTION
Scripts can be then called via Alt+C and number.

This should be a reasonable compromise that does not require a reimplementation of script wxFileHistory to allow for custom keybindings.