### PR TITLE
Provide WM class in Linux desktop entry

### DIFF
--- a/platform/linux/com.strlen.TreeSheets.desktop
+++ b/platform/linux/com.strlen.TreeSheets.desktop
@@ -9,6 +9,7 @@ TryExec=TreeSheets
 Exec=TreeSheets %f
 Terminal=false
 Icon=com.strlen.TreeSheets
+StartupWMClass=TreeSheets
 MimeType=application/x-treesheets;
 Categories=Office;Utility;Spreadsheet;TextEditor;
 Keywords=mindmaps;knowledge;organizer;organiser;information;brainstorming;pim;database;todo;


### PR DESCRIPTION
This is necessary on Wayland for the application to display the correct window & taskbar icon.