### PR TITLE
Provide call to get current timestamp

### DIFF
--- a/src/lobster_impl.cpp
+++ b/src/lobster_impl.cpp
@@ -182,6 +182,14 @@ nfr("set_window_size", "width,height", "II", "", "resizes the window",
 nfr("get_last_edit", "", "", "I",
     "gets the timestamp of the last edit in milliseconds since the Unix/C epoch",
     [](StackPtr &, VM &) { return Value(si->GetLastEdit()); });
+
+nfr("get_current_time", "", "", "I",
+    "gets the current timestamp in milliseconds since the Unix/C epoch", [](StackPtr &, VM &) {
+        auto now = std::chrono::system_clock::now();
+        auto duration = now.time_since_epoch();
+        auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+        return Value(milliseconds);
+    });
 }
 
 NativeRegistry natreg;  // FIXME: global.


### PR DESCRIPTION
This allows for e.g. build timers in a TreeSheets file by combining the current timestamp with the last edit timestamp.

Example for lobster script:
```
ts.goto_selection()
var lastedit = ts.get_last_edit()
var now = ts.get_current_time()
var duration = (now - lastedit)
var hours = duration / (1000 * 60 * 60)
var hoursrest = duration % (1000 * 60 * 60)
var minutes = hoursrest / (1000 * 60)
var minutesleft = hoursrest % (1000 * 60)
var seconds = minutesleft / (1000)
ts.set_text("{hours} h {minutes} min {seconds} seconds")
```