### PR TITLE
Use LINE_SEPARATOR for A_EXPTEXT

### DIFF
--- a/src/cell.h
+++ b/src/cell.h
@@ -232,7 +232,7 @@ struct Cell {
             return L"\"" + str + L"\"";
         }
         if (sel.cursor != sel.cursorend) return str;
-        str.Append(L"\n");
+        str.Append(LINE_SEPERATOR);
         if (grid) str.Append(grid->ToText(indent, sel, format, doc, inheritstyle, root));
         if (format == A_EXPXML) {
             str.Prepend(L">");


### PR DESCRIPTION
On Wayland GTK, the clipboard manipulates the text content with \r\n newlines. We want to recognize our own text in System::clipboardcopy in order to use the cell in System::cellclipboard.