### PR TITLE
Configure CPack + Inno Setup to allow installing on arm64 windows (under x64 emulation)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,6 +276,7 @@ elseif(WIN32)
         "russian"
     )
     set(CPACK_INNOSETUP_SETUP_PrivilegesRequired "lowest")
+    set(CPACK_INNOSETUP_SETUP_ArchitecturesAllowed "x64compatible")
     set(CPACK_INNOSETUP_IGNORE_README_PAGE ON)
     set(CPACK_INNOSETUP_IGNORE_LICENSE_PAGE ON)
     set(CPACK_INNOSETUP_USE_MODERN_WIZARD ON)


### PR DESCRIPTION
Currently, Inno Setup refuses to install TreeSheets on Windows 11 arm64; running the installer results in a messagebox saying `This program does not support the version of Windows your computer is running`. If I download the zip, TreeSheets runs fine under x64 emulation.

Per https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesallowed and https://stackoverflow.com/a/78644911, setting the Inno Setup directive `ArchitecturesAllowed=x64compatible` should allow setup to run.

`CPACK_INNOSETUP_SETUP_<directive>` allows [adding arbitrary Inno Setup directives to the config CPack generates](https://cmake.org/cmake/help/latest/cpack_gen/innosetup.html#variable:CPACK_INNOSETUP_SETUP_%3Cdirective%3E). Combining those together to add `set(CPACK_INNOSETUP_SETUP_ArchitecturesAllowed "x64compatible")` to `CMakeLists.txt` [results in an installer](https://github.com/vivlim/treesheets/releases/tag/2) that is usable on my arm64 machine.

I also tried the installer on an x64 Windows machine and it still works there.